### PR TITLE
Xfail region

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -8,8 +8,12 @@ offline = false
 [test_marketplace_add_review.py]
 
 [test_marketplace_change_region_anonymous.py]
+# Bug 941307 - Remove region selector from user settings
+expected = fail
 
 [test_marketplace_change_region_login.py]
+# Bug 941307 - Remove region selector from user settings
+expected = fail
 
 [test_marketplace_feedback_anonymous.py]
 


### PR DESCRIPTION
As per bug comment https://bugzilla.mozilla.org/show_bug.cgi?id=941307#c1 we have to change our tests:
## QA
- On desktop: search for ":debug" (or hold the logo for 3 seconds) and a <select> menus for Region/Carrier appear.
- On mobile: hold the logo for 3 seconds and <select> menus for Region/Carrier appear.
