### PR TITLE
Bug 993114 - [marketplace-tests-gaia] Add a test to purchase an app using Zippy

### DIFF
--- a/marketplacetests/marketplace/app.py
+++ b/marketplacetests/marketplace/app.py
@@ -35,14 +35,13 @@ class Marketplace(Base):
     _search_locator = (By.ID, 'search-q')
     _signed_in_notification_locator = (By.CSS_SELECTOR, '#notification.show')
 
+    # System app notification install message
+    _notification_install_locator = (By.CSS_SELECTOR, '#system-banner > p')
+
     def __init__(self, marionette, app_name=False):
         Base.__init__(self, marionette)
         if app_name:
             self.name = app_name
-
-    def switch_to_marketplace_frame(self):
-        """Only Marketplace production has a frame for the app."""
-        self.marionette.switch_to_frame(self.marionette.find_element(*self._marketplace_iframe_locator))
 
     def launch(self):
         Base.launch(self, launch_timeout=120000)
@@ -154,3 +153,9 @@ class Marketplace(Base):
     def submit_feedback(self):
         self.wait_for_element_displayed(*self._feedback_submit_button_locator)
         self.marionette.find_element(*self._feedback_submit_button_locator).tap()
+
+    @property
+    def install_notification_message(self):
+        self.marionette.switch_to_frame()
+        self.wait_for_element_displayed(*self._notification_install_locator)
+        return self.marionette.find_element(*self._notification_install_locator).text

--- a/marketplacetests/payment/app.py
+++ b/marketplacetests/payment/app.py
@@ -63,3 +63,4 @@ class Payment(Base):
         self.marionette.find_element(*self._buy_button_locator).tap()
         self.marionette.switch_to_frame()
         self.wait_for_element_not_present(*self._payment_frame_locator)
+        self.marionette.switch_to_frame()

--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -15,6 +15,8 @@ offline = false
 
 [test_marketplace_login.py]
 
+[test_marketplace_purchase_app.py]
+
 [test_marketplace_search_and_install_app.py]
 
 [test_marketplace_search_for_paid_app.py]

--- a/marketplacetests/tests/test_marketplace_purchase_app.py
+++ b/marketplacetests/tests/test_marketplace_purchase_app.py
@@ -1,0 +1,46 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest.apps.homescreen.regions.confirm_install import ConfirmInstall
+from gaiatest.mocks.persona_test_user import PersonaTestUser
+
+from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
+from marketplacetests.marketplace.app import Marketplace
+
+
+class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
+
+    def test_purchase_app(self):
+
+        APP_NAME = 'Test Zippy With Me'
+        PIN = '1234'
+
+        if self.apps.is_app_installed(APP_NAME):
+            self.apps.uninstall(APP_NAME)
+
+        user = PersonaTestUser().create_user(verified=True,
+                                             env={"browserid": "firefoxos.persona.org",
+                                                  "verifier": "marketplace-dev.allizom.org"})
+        marketplace = Marketplace(self.marionette, 'Marketplace Dev')
+        marketplace.launch()
+
+        marketplace.login(user)
+
+        marketplace.set_region('United States')
+
+        details_page = marketplace.navigate_to_app(APP_NAME)
+        payment = details_page.tap_purchase_button()
+
+        payment.create_pin(PIN)
+        payment.wait_for_buy_app_section_displayed()
+        self.assertIn(APP_NAME, payment.app_name)
+        payment.tap_buy_button()
+
+        # Confirm the installation and wait for the app icon to be present
+        confirm_install = ConfirmInstall(self.marionette)
+        confirm_install.tap_confirm()
+
+        self.assertEqual('%s installed' % APP_NAME, marketplace.install_notification_message)
+        marketplace.launch()
+        self.assertEqual('Launch', details_page.install_button_text)

--- a/marketplacetests/tests/test_marketplace_search_for_paid_app.py
+++ b/marketplacetests/tests/test_marketplace_search_for_paid_app.py
@@ -12,6 +12,9 @@ class TestSearchMarketplacePaidApp(MarketplaceGaiaTestCase):
 
         APP_NAME = 'Test Zippy With Me'
 
+        if self.apps.is_app_installed(APP_NAME):
+            self.apps.uninstall(APP_NAME)
+
         marketplace = Marketplace(self.marionette, 'Marketplace Dev')
         marketplace.launch()
 


### PR DESCRIPTION
This includes a commit from issue #22 as some of the same things were needed, so that should be merged first and then I'll rebase this if necessary.

This is also quite a bit of duplication in this test from the other test, and there is some more cleanup/refactoring to do of the code in this repo, but I wanted to get this coverage in for now, and then deal with cleaning the other stuff up later.
