### PR TITLE
Bug 997951 - [marketplace-tests-gaia] Clean up and bolster some tests which are failing intermittently

### DIFF
--- a/marketplacetests/marketplace/app.py
+++ b/marketplacetests/marketplace/app.py
@@ -40,10 +40,6 @@ class Marketplace(Base):
         if app_name:
             self.name = app_name
 
-    def switch_to_marketplace_frame(self):
-        """Only Marketplace production has a frame for the app."""
-        self.marionette.switch_to_frame(self.marionette.find_element(*self._marketplace_iframe_locator))
-
     def launch(self):
         Base.launch(self, launch_timeout=120000)
         self.wait_for_element_not_displayed(*self._loading_fragment_locator)

--- a/marketplacetests/marketplace/regions/app_details.py
+++ b/marketplacetests/marketplace/regions/app_details.py
@@ -37,17 +37,15 @@ class Details(Base):
         return int(self.marionette.find_element(*self._first_review_locator).get_attribute('class')[-1])
 
     def tap_write_review(self):
-        self.wait_for_element_present(*self._write_review_locator)
-        write_review_button = self.marionette.find_element(*self._write_review_locator)
-        # element.tap() isn't working here
-        # Bug 878750 - el.tap() and click() do not work on "Write a review" button
-        write_review_button.tap()
+        self.wait_for_element_displayed(*self._write_review_locator)
+        self.marionette.find_element(*self._write_review_locator).tap()
         from marketplacetests.marketplace.regions.review_box import AddReview
         return AddReview(self.marionette)
 
     def tap_purchase_button(self):
+        self.wait_for_element_displayed(*self._install_button_locator)
         self.marionette.find_element(*self._install_button_locator).tap()
-        # Return payment object
 
+        # Return payment object
         from marketplacetests.payment.app import Payment
         return Payment(self.marionette)

--- a/marketplacetests/marketplace/regions/debug.py
+++ b/marketplacetests/marketplace/regions/debug.py
@@ -17,8 +17,6 @@ class Debug(Base):
 
     def tap_back(self):
         self.marionette.find_element(*self._back_button_locator).tap()
-        from marketplacetests.marketplace.app import Marketplace
-        return Marketplace(self.marionette)
 
     def select_region(self, region):
         self.marionette.find_element(*self._region_select_locator).tap()

--- a/marketplacetests/marketplace/regions/review_box.py
+++ b/marketplacetests/marketplace/regions/review_box.py
@@ -6,7 +6,7 @@ from marionette.by import By
 from gaiatest.apps.base import Base
 
 
-class AddReview(Base, dict):
+class AddReview(Base):
     """
     Page for adding reviews.
     """
@@ -16,9 +16,9 @@ class AddReview(Base, dict):
     _review_box_locator = (By.CSS_SELECTOR, '.add-review-form')
     _rating_locator = (By.CSS_SELECTOR, ".ratingwidget.stars-0 > label[data-stars='%s']")
 
-    def __init__(self, marionette, **kwargs):
+    def __init__(self, marionette):
         Base.__init__(self, marionette)
-        self.wait_for_element_present(*self._review_box_locator)
+        self.wait_for_element_displayed(*self._review_box_locator)
 
     def set_review_rating(self, rating):
         self.marionette.find_element(self._rating_locator[0], self._rating_locator[1] % rating).tap()

--- a/marketplacetests/tests/test_marketplace_add_review.py
+++ b/marketplacetests/tests/test_marketplace_add_review.py
@@ -13,37 +13,20 @@ from marketplacetests.marketplace.app import Marketplace
 
 class TestMarketplaceAddReview(MarketplaceGaiaTestCase):
 
-    def setUp(self):
-        MarketplaceGaiaTestCase.setUp(self)
-
-        self.user = PersonaTestUser().create_user(verified=True,
-                                                  env={"browserid": "firefoxos.persona.org", "verifier": "marketplace-dev.allizom.org"})
-
     def test_add_review(self):
+        APP_NAME = 'SoundCloud'
+        user = PersonaTestUser().create_user(verified=True,
+                                                  env={"browserid": "firefoxos.persona.org", "verifier": "marketplace-dev.allizom.org"})
 
         marketplace = Marketplace(self.marionette, 'Marketplace dev')
         marketplace.launch()
+        marketplace.login(user)
+        details_page = marketplace.navigate_to_app(APP_NAME)
 
-        # Sign in
-        settings = marketplace.tap_settings()
-        persona = settings.tap_sign_in()
-        persona.login(self.user.email, self.user.password)
-
-        self.marionette.switch_to_frame()
-        marketplace.launch()
-        settings.wait_for_sign_out_button()
-
-        # Search and select app
-        results = marketplace.search('SoundCloud')
-        self.assertGreater(len(results.search_results), 0, 'No results found.')
-        details_page = results.search_results[0].tap_app()
-
-        # Setting your default values for review
         current_time = str(time.time()).split('.')[0]
         rating = random.randint(1, 5)
         body = 'This is a test %s' % current_time
 
-        # Adding the review
         review_box = details_page.tap_write_review()
         review_box.write_a_review(rating, body)
 

--- a/marketplacetests/tests/test_marketplace_search_for_paid_app.py
+++ b/marketplacetests/tests/test_marketplace_search_for_paid_app.py
@@ -12,6 +12,9 @@ class TestSearchMarketplacePaidApp(MarketplaceGaiaTestCase):
 
         APP_NAME = 'Test Zippy With Me'
 
+        if self.apps.is_app_installed(APP_NAME):
+            self.apps.uninstall(APP_NAME)
+
         marketplace = Marketplace(self.marionette, 'Marketplace Dev')
         marketplace.launch()
 


### PR DESCRIPTION
This includes setting the default marionette timeouts to 60 seconds as we frequently see timeouts as intermittents.
Also includes some new waits and some general code cleanup.
