### PR TITLE
Bug 1006219 - [marketplace-tests-gaia] Re-enable test_search_paid_app when price becomes visible

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -24,8 +24,6 @@ expected = fail
 [test_marketplace_search_and_install_app.py]
 
 [test_marketplace_search_for_paid_app.py]
-# Bug 985508 - Price element in Marketplace app not visible to marionette
-expected = fail
 
 [test_marketplace_without_connectivity.py]
 fail-if = device == "desktop"

--- a/marketplacetests/tests/test_marketplace_search_for_paid_app.py
+++ b/marketplacetests/tests/test_marketplace_search_for_paid_app.py
@@ -27,8 +27,9 @@ class TestSearchMarketplacePaidApp(MarketplaceGaiaTestCase):
         for result in search_results:
             if result.name == APP_NAME:
                 saved_price = result.price
+                # TODO: Remove this hack once bug https://bugzilla.mozilla.org/show_bug.cgi?id=985508 has been fixed
                 try:
-                    float(saved_price)
+                    float(saved_price[2:])
                 except ValueError:
                     self.fail(
                         'The app: %s does not appear to be a paid app. Its price is "%s".' %


### PR DESCRIPTION
Although the price has not become visible, an additional hack has been added which allows the test to pass
