### PR TITLE
Bug 1033263 - [marketplace-tests-gaia] "test_marketplace_search_and_inst...

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -24,6 +24,8 @@ expected = fail
 expected = fail
 
 [test_marketplace_search_and_install_app.py]
+# Bug 1033503 - All packaged app installs fail with "Install Error: MANIFEST_URL_ERROR"
+expected = fail
 
 [test_marketplace_search_for_paid_app.py]
 


### PR DESCRIPTION
...all_app" is failing with "MANIFEST_URL_ERROR"
