### PR TITLE
Xfail tests that use Zippy app because Bug 1043838 - [marketplace-te...

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -18,6 +18,8 @@ expected = fail
 [test_marketplace_login.py]
 
 [test_marketplace_login_during_purchase.py]
+# Bug 1043838 - [marketplace-tests-gaia] Re-create "Test Zippy With Me" app
+expected = fail
 
 [test_marketplace_purchase_app.py]
 # Bug 1013397 - Purchase app flow produces error after create/confirm pin
@@ -28,6 +30,8 @@ expected = fail
 expected = fail
 
 [test_marketplace_search_for_paid_app.py]
+# Bug 1043838 - [marketplace-tests-gaia] Re-create "Test Zippy With Me" app
+expected = fail
 
 [test_marketplace_without_connectivity.py]
 fail-if = device == "desktop"


### PR DESCRIPTION
...sts-gaia] Re-create "Test Zippy With Me" app
