### PR TITLE
Unxfail tests that reply on Test Zippy with Me app

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -18,8 +18,6 @@ expected = fail
 [test_marketplace_login.py]
 
 [test_marketplace_login_during_purchase.py]
-# Bug 1043838 - [marketplace-tests-gaia] Re-create "Test Zippy With Me" app
-expected = fail
 
 [test_marketplace_purchase_app.py]
 # Bug 1013397 - Purchase app flow produces error after create/confirm pin
@@ -30,8 +28,6 @@ expected = fail
 expected = fail
 
 [test_marketplace_search_for_paid_app.py]
-# Bug 1043838 - [marketplace-tests-gaia] Re-create "Test Zippy With Me" app
-expected = fail
 
 [test_marketplace_without_connectivity.py]
 fail-if = device == "desktop"


### PR DESCRIPTION
Bug 1043838 has been fixed

The tests are passing locally and on CI [1] 

[1] http://selenium.qa.mtv2.mozilla.com:8080/job/b2g.hamachi.mozilla-b2g28_v1_3.v1.3.marketplace/1867/HTML_Report/
