### PR TITLE
Pin screen

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -6,7 +6,6 @@ online = true
 offline = false
 
 [test_marketplace_add_review.py]
-disabled = https://github.com/mozilla/fxa-python-client/issues/25
 
 [test_marketplace_create_confirm_pin.py]
 disabled = Bug 1076279 - Zippy dev is not configured right
@@ -21,7 +20,6 @@ disabled = Bug 1076279 - Zippy dev is not configured right
 disabled = Bug 1076279 - Zippy dev is not configured right
 
 [test_marketplace_login_from_app_details_page.py]
-disabled = https://github.com/mozilla/fxa-python-client/issues/25
 
 [test_marketplace_login_from_my_apps.py]
 

--- a/marketplacetests/tests/test_marketplace_add_review.py
+++ b/marketplacetests/tests/test_marketplace_add_review.py
@@ -5,6 +5,8 @@
 import time
 import random
 
+from fxapom.fxapom import FxATestAccount
+
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
 
@@ -13,12 +15,11 @@ class TestMarketplaceAddReview(MarketplaceGaiaTestCase):
 
     def test_add_review(self):
         APP_NAME = 'SoundCloud'
-        username = self.testvars['marketplace']['username']
-        password = self.testvars['marketplace']['password']
+        acct = FxATestAccount(use_prod=False).create_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
-        marketplace.login(username, password)
+        marketplace.login(acct.email, acct.password)
         details_page = marketplace.navigate_to_app(APP_NAME)
 
         current_time = str(time.time()).split('.')[0]

--- a/marketplacetests/tests/test_marketplace_create_confirm_pin.py
+++ b/marketplacetests/tests/test_marketplace_create_confirm_pin.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from fxapom.fxapom import FxATestAccount
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
@@ -12,8 +13,7 @@ class TestMarketplaceCreateConfirmPin(MarketplaceGaiaTestCase):
 
         APP_NAME = 'Test Zippy With Me'
         PIN = '1234'
-        username = self.testvars['marketplace']['username']
-        password = self.testvars['marketplace']['password']
+        acct = FxATestAccount(use_prod=False).create_account()
 
         if self.apps.is_app_installed(APP_NAME):
             self.apps.uninstall(APP_NAME)
@@ -21,7 +21,7 @@ class TestMarketplaceCreateConfirmPin(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
 
-        marketplace.login(username, password)
+        marketplace.login(acct.email, acct.password)
 
         marketplace.set_region('United States')
 

--- a/marketplacetests/tests/test_marketplace_feedback_login.py
+++ b/marketplacetests/tests/test_marketplace_feedback_login.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from fxapom.fxapom import FxATestAccount
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
@@ -11,13 +12,12 @@ class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
     test_comment = 'This is a test comment.'
 
     def test_marketplace_feedback_user(self):
-        username = self.testvars['marketplace']['username']
-        password = self.testvars['marketplace']['password']
+        acct = FxATestAccount(use_prod=False).create_account()
 
         # launch marketplace dev and go to marketplace
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
-        marketplace.login(username, password)
+        marketplace.login(acct.email, acct.password)
 
         # go to feedback tab
         marketplace.select_setting_feedback()

--- a/marketplacetests/tests/test_marketplace_login.py
+++ b/marketplacetests/tests/test_marketplace_login.py
@@ -1,9 +1,9 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from fxapom.fxapom import FxATestAccount
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
-
 from marketplacetests.marketplace.app import Marketplace
 
 
@@ -17,13 +17,12 @@ class TestMarketplaceLogin(MarketplaceGaiaTestCase):
 
     def test_login_marketplace(self):
         # https://moztrap.mozilla.org/manage/case/4134/
-        username = self.testvars['marketplace']['username']
-        password = self.testvars['marketplace']['password']
+        acct = FxATestAccount(use_prod=False).create_account()
 
         settings = self.marketplace.tap_settings()
         ff_accounts = settings.tap_sign_in()
 
-        ff_accounts.login(username, password)
+        ff_accounts.login(acct.email, acct.password)
 
         # switch back to Marketplace
         self.marketplace.switch_to_marketplace_frame()
@@ -33,7 +32,7 @@ class TestMarketplaceLogin(MarketplaceGaiaTestCase):
         self.marketplace.wait_for_notification_message_not_displayed()
 
         # Verify that user is logged in
-        self.assertEqual(username, settings.email)
+        self.assertEqual(acct.email, settings.email)
 
         # Sign out, which should return to the Marketplace home screen
         settings.tap_sign_out()

--- a/marketplacetests/tests/test_marketplace_login_during_purchase.py
+++ b/marketplacetests/tests/test_marketplace_login_during_purchase.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from fxapom.fxapom import FxATestAccount
 from marionette.errors import StaleElementException
 from marionette.wait import Wait
 
@@ -14,8 +14,7 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
     def test_purchase_app(self):
 
         APP_NAME = 'Test Zippy With Me'
-        username = self.testvars['marketplace']['username']
-        password = self.testvars['marketplace']['password']
+        acct = FxATestAccount(use_prod=False).create_account()
 
         if self.apps.is_app_installed(APP_NAME):
             self.apps.uninstall(APP_NAME)
@@ -27,7 +26,7 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
 
         details_page = marketplace.navigate_to_app(APP_NAME)
         ff_accounts = details_page.tap_purchase_button(is_logged_in=False)
-        ff_accounts.login(username, password)
+        ff_accounts.login(acct.email, acct.password)
 
         # Switch back to the Marketplace frame and wait for the install button to update
         marketplace.switch_to_marketplace_frame()

--- a/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
+++ b/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
@@ -5,6 +5,8 @@
 import time
 import random
 
+from fxapom.fxapom import FxATestAccount
+
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
 
@@ -13,15 +15,14 @@ class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
 
     def test_marketplace_login_from_app_details_page(self):
         APP_NAME = 'SoundCloud'
-        username = self.testvars['marketplace']['username']
-        password = self.testvars['marketplace']['password']
+        acct = FxATestAccount(use_prod=False).create_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
         details_page = marketplace.navigate_to_app(APP_NAME)
 
         ff_accounts = details_page.tap_write_review(logged_in=False)
-        ff_accounts.login(username, password)
+        ff_accounts.login(acct.email, acct.password)
 
         # switch back to Marketplace
         marketplace.switch_to_marketplace_frame()

--- a/marketplacetests/tests/test_marketplace_login_from_my_apps.py
+++ b/marketplacetests/tests/test_marketplace_login_from_my_apps.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
-
 from marketplacetests.marketplace.app import Marketplace
 
 

--- a/marketplacetests/tests/test_marketplace_purchase_app.py
+++ b/marketplacetests/tests/test_marketplace_purchase_app.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from fxapom.fxapom import FxATestAccount
 from gaiatest.apps.homescreen.regions.confirm_install import ConfirmInstall
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
@@ -14,8 +14,7 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
 
         APP_NAME = 'Test Zippy With Me'
         PIN = '1234'
-        username = self.testvars['marketplace']['username']
-        password = self.testvars['marketplace']['password']
+        acct = FxATestAccount(use_prod=False).create_account()
 
         if self.apps.is_app_installed(APP_NAME):
             self.apps.uninstall(APP_NAME)
@@ -23,7 +22,7 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
 
-        marketplace.login(username, password)
+        marketplace.login(acct.email, acct.password)
 
         marketplace.set_region('United States')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+gaiatest-v2.0
+-e git+https://github.com/bobsilverberg/fxapom.git@remove_fxos#egg=fxapom

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ try:
 except (OSError, IOError):
     description = ''
 
-# dependencies
-deps = ['gaiatest-v2.0']
-
 setup(name='marketplacetests',
       version='1.0',
       description="Gaia UI test for Marketplace",
@@ -22,6 +19,5 @@ setup(name='marketplacetests',
       url='https://wiki.mozilla.org/QA/Execution/Web_Testing',
       license='MPL',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      install_requires=deps,
       include_package_data=True,
       )


### PR DESCRIPTION
These changes build on those in PR #65 and are trying to get Payments working again, so only the 2nd commit is relevant. I am able to get through the "Create PIN" screen, but cannot seem to automate the "Confirm PIN" screen, which is quite strange.

What seems to be happening is that when the "Continue" button is tapped, taking us to the Confirm screen, they keyboard goes away and I cannot seem to make it come back no matter what elements I tap on the screen via Marionette.

I need to abandon this for now, but hopefully @AndreiH, perhaps with some help from @davehunt, will be able to get past this issue which will bring us very close to having payment testing reenabled.
  