### PR TITLE
Xfail paymets tests because Bug 1132040

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -8,6 +8,8 @@ offline = false
 [test_marketplace_add_review.py]
 
 [test_marketplace_create_confirm_pin.py]
+expected = fail
+# Bug 1132040 - [dev] Payments does not work on Flame device build 2.0 dev Marketplace app
 
 [test_marketplace_feedback_anonymous.py]
 
@@ -16,6 +18,8 @@ offline = false
 [test_marketplace_login.py]
 
 [test_marketplace_login_during_purchase.py]
+expected = fail
+# Bug 1132040 - [dev] Payments does not work on Flame device build 2.0 dev Marketplace app
 
 [test_marketplace_login_from_app_details_page.py]
 


### PR DESCRIPTION
I investigated the 2 failures on http://jenkins1.qa.scl3.mozilla.com/job/flame-kk-319.mozilla-b2g32_v2_0.ui.marketplace-tests/96/HTML_Report/

Opened Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1132040