### PR TITLE
Fix test_purchase_app by adding an appropriate wait/switch_to

### DIFF
--- a/marketplacetests/tests/test_marketplace_purchase_app.py
+++ b/marketplacetests/tests/test_marketplace_purchase_app.py
@@ -36,6 +36,7 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
         payment.wait_for_buy_app_section_displayed()
         self.assertIn(APP_NAME, payment.app_name)
         payment.tap_buy_button()
+        self.wait_for_downloads_to_finish()
 
         # Confirm the installation and wait for the app icon to be present
         confirm_install = ConfirmInstall(self.marionette)


### PR DESCRIPTION
This should fix the failure as currently seen at https://webqa-ci.mozilla.com/view/Marketplace/job/flame-kk-319.mozilla-b2g32_v2_0.nightly.ui.marketplace-tests/110/testReport/test_marketplace_purchase_app/TestMarketplacePurchaseApp/test_purchase_app/

@m8ttyB / @davehunt r?