### PR TITLE
Update wait_for_notification_message_displayed to allow specifying a message for which to wait

### DIFF
--- a/marketplacetests/marketplace/app.py
+++ b/marketplacetests/marketplace/app.py
@@ -4,6 +4,7 @@
 
 from marionette.by import By
 from marionette.keys import Keys
+from marionette.wait import Wait
 from gaiatest.apps.base import Base
 
 
@@ -72,7 +73,10 @@ class Marketplace(Base):
         self.wait_for_element_displayed(*self._offline_message_locator)
         return self.marionette.find_element(*self._offline_message_locator).text
 
-    def wait_for_notification_message_displayed(self):
+    def wait_for_notification_message_displayed(self, message=None):
+        if message:
+            Wait(marionette=self.marionette).until(
+                lambda m: self.notification_message == message)
         self.wait_for_element_displayed(*self._notification_locator)
 
     def wait_for_notification_message_not_displayed(self):

--- a/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
+++ b/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
@@ -34,9 +34,8 @@ class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
         review_box = AddReview(self.marionette)
 
         review_box.write_a_review(rating, body)
-        marketplace.wait_for_notification_message_displayed()
+        marketplace.wait_for_notification_message_displayed('Your review was successfully posted. Thanks!')
 
         # Check if review was added correctly
-        self.assertEqual(marketplace.notification_message, "Your review was successfully posted. Thanks!")
         self.assertEqual(details_page.first_review_rating, rating)
         self.assertEqual(details_page.first_review_body, body)


### PR DESCRIPTION

This fixes #80 - test_marketplace_login_from_app_details_page.py is failing on CI