### PR TITLE
Wait for search input to be displayed before interacting with it

### DIFF
--- a/marketplacetests/marketplace/app.py
+++ b/marketplacetests/marketplace/app.py
@@ -93,6 +93,7 @@ class Marketplace(Base):
         return [Result(self.marionette, app) for app in self.marionette.find_elements(*self._gallery_apps_locator)]
 
     def search(self, term):
+        self.wait_for_element_displayed(*self._search_locator)
         search_box = self.marionette.find_element(*self._search_locator)
 
         # search for the app
@@ -104,6 +105,7 @@ class Marketplace(Base):
 
     def set_region(self, region):
         # go to the :debug page
+        self.wait_for_element_displayed(*self._search_locator)
         search_box = self.marionette.find_element(*self._search_locator)
         search_box.send_keys(':debug')
         search_box.send_keys(Keys.RETURN)


### PR DESCRIPTION
I noticed when trying to reproduce issue #83, that the send_keys was happening before the input became visible. This still allowed the tests to pass locally for me, but I am guessing this might be the cause of issue #83. So (hopefully) this fixes #83 - Tests are failing because of an issue setting the region

@davehunt / @m8ttyB r?