### PR TITLE
Use first popular app, rather than SoundCloud

### DIFF
--- a/marketplacetests/tests/test_marketplace_add_review.py
+++ b/marketplacetests/tests/test_marketplace_add_review.py
@@ -14,13 +14,15 @@ from marketplacetests.marketplace.app import Marketplace
 class TestMarketplaceAddReview(MarketplaceGaiaTestCase):
 
     def test_add_review(self):
-        APP_NAME = 'SoundCloud'
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
+
+        app_name = marketplace.popular_apps[0].name
+
         marketplace.login(acct.email, acct.password)
-        details_page = marketplace.navigate_to_app(APP_NAME)
+        details_page = marketplace.navigate_to_app(app_name)
 
         current_time = str(time.time()).split('.')[0]
         rating = random.randint(1, 5)

--- a/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
+++ b/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
@@ -15,12 +15,13 @@ from marketplacetests.marketplace.app import Marketplace
 class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
 
     def test_marketplace_login_from_app_details_page(self):
-        APP_NAME = 'SoundCloud'
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
-        details_page = marketplace.navigate_to_app(APP_NAME)
+
+        app_name = marketplace.popular_apps[0].name
+        details_page = marketplace.navigate_to_app(app_name)
 
         ff_accounts = details_page.tap_write_review(logged_in=False)
         ff_accounts.login(acct.email, acct.password)


### PR DESCRIPTION
There have been tests which are failing because SoundCloud is not found.
While this may be due to a different issue, it seems a better approach to
use an app we know can currently be found, rather than one we assume
can be found.

Note that I sent an email to the mailing list about this, so we should hold off on merging this until @krupa gives us an answer.

A review would still be appreciated. :)