### PR TITLE
Bug 1014170 - [marketplace-tests-gaia] Add a test to check that entering an incorrrect PIN throws an error message

### DIFF
--- a/marketplacetests/payment/app.py
+++ b/marketplacetests/payment/app.py
@@ -4,8 +4,10 @@
 from gaiatest.apps.base import Base
 from marionette import expected, By, Wait
 
+from marketplacetests.marketplace.app import Marketplace
 
-class Payment(Base):
+
+class Payment(Marketplace):
 
     _payment_frame_locator = (By.CSS_SELECTOR, "#trustedui-frame-container > iframe")
 
@@ -16,15 +18,15 @@ class Payment(Base):
     _pin_digit_holder_locator = (By.CSS_SELECTOR, '.pinbox span')
     _pin_continue_button_locator = (By.CSS_SELECTOR, '.cta')
     _pin_heading_locator = (By.CSS_SELECTOR, 'section.content h1')
+    _pin_error_locator = (By.CSS_SELECTOR, 'section.content p.err-msg')
     _cancel_pin_button_locator = (By.CSS_SELECTOR, '.button.cancel')
 
     # Final buy app panel
     _app_name_locator = (By.CSS_SELECTOR, '.product .title')
     _buy_button_locator = (By.XPATH, "//button[text()='Buy']")
-    _cancel_button_locator = (By.XPATH, "//button[text()='Cancel']")
+    _cancel_button_locator = (By.CSS_SELECTOR, '.buttons button.cancel')
     _confirm_payment_header_locator = (By.CSS_SELECTOR, 'main > h1')
     _in_app_product_name_locator = (By.CSS_SELECTOR, '.title')
-    _in_app_confirm_buy_button_locator = (By.ID, 'uxBtnBuyNow')
 
     def __init__(self, marionette):
         Base.__init__(self, marionette)
@@ -52,6 +54,11 @@ class Payment(Base):
     @property
     def pin_heading(self):
         return self.marionette.find_element(*self._pin_heading_locator).text
+
+    @property
+    def pin_error(self):
+        self.wait_for_element_displayed(*self._pin_error_locator)
+        return self.marionette.find_element(*self._pin_error_locator).text
 
     def create_pin(self, pin):
         element = Wait(self.marionette).until(
@@ -104,14 +111,18 @@ class Payment(Base):
         self.wait_for_element_displayed(*self._buy_button_locator)
 
     def tap_buy_button(self):
+        self._tap_payment_button(self._buy_button_locator)
+
+    def tap_cancel_button(self):
+        self._tap_payment_button(self._cancel_button_locator)
+
+    def _tap_payment_button(self, button_locator):
         self.marionette.switch_to_frame()
         self.wait_for_element_not_displayed(*self._loading_throbber_locator)
         payment_iframe = self.marionette.find_element(*self._payment_frame_locator)
         self.marionette.switch_to_frame(payment_iframe)
-        if self.is_element_present(*self._buy_button_locator):
-            self.marionette.find_element(*self._buy_button_locator).tap()
-        else:
-            self.marionette.find_element(*self._in_app_confirm_buy_button_locator).tap()
+        self.wait_for_element_displayed(*button_locator)
+        self.marionette.find_element(*button_locator).tap()
         self.marionette.switch_to_frame()
         self.wait_for_element_not_present(*self._payment_frame_locator)
-        self.apps.switch_to_displayed_app()
+        self.switch_to_marketplace_frame()

--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -13,17 +13,19 @@ offline = false
 
 [test_marketplace_feedback_login.py]
 
-[test_marketplace_login.py]
+[test_marketplace_incorrect_pin.py]
 
 [test_marketplace_in_app_not_you_login_feature.py]
 
-[test_marketplace_make_an_in_app_payment.py]
+[test_marketplace_login.py]
 
 [test_marketplace_login_during_purchase.py]
 
 [test_marketplace_login_from_app_details_page.py]
 
 [test_marketplace_login_from_my_apps.py]
+
+[test_marketplace_make_an_in_app_payment.py]
 
 [test_marketplace_purchase_app.py]
 

--- a/marketplacetests/tests/test_marketplace_incorrect_pin.py
+++ b/marketplacetests/tests/test_marketplace_incorrect_pin.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from fxapom.fxapom import FxATestAccount
+
+from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
+from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.payment.app import Payment
+
+
+class TestMarketplaceIncorrectPin(MarketplaceGaiaTestCase):
+
+    def test_incorrect_pin(self):
+
+        app_name = 'Test Zippy With Me'
+        valid_pin = '1234'
+        invalid_pin = '1111'
+        acct = FxATestAccount(base_url=self.base_url).create_account()
+
+        if self.apps.is_app_installed(app_name):
+            self.apps.uninstall(app_name)
+
+        marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
+        marketplace.launch()
+
+        marketplace.login(acct.email, acct.password)
+
+        marketplace.set_region('United States')
+
+        details_page = marketplace.navigate_to_app(app_name)
+        details_page.tap_install_button()
+
+        payment = Payment(self.marionette)
+        payment.create_pin(valid_pin)
+        payment.wait_for_buy_app_section_displayed()
+        self.assertIn(app_name, payment.app_name)
+        payment.tap_cancel_button()
+
+        marketplace.wait_for_notification_message_displayed('Payment cancelled.')
+        details_page.tap_install_button()
+        payment.switch_to_payment_frame()
+        payment.enter_pin(invalid_pin)
+        self.assertEqual('Wrong PIN', payment.pin_error)

--- a/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
+++ b/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
@@ -43,5 +43,6 @@ class TestMakeInAppPayment(MarketplaceGaiaTestCase):
         self.assertEqual('test 0.10USD', payment.in_app_product_name)
 
         payment.tap_buy_button()
+        self.apps.switch_to_displayed_app()
         tester_app.wait_for_bought_products_displayed()
         self.assertEqual('test 0.10USD', tester_app.bought_product_text)


### PR DESCRIPTION
This adds a new test that is part of a Q1 goal.

It also includes a bit of refactoring, as we need to be able to call `switch_to_marketplace_frame` from both the marketplace app object and the payment app object.

@davehunt r?