### PR TITLE
Unpin fxapom as we are in full control of it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (OSError, IOError):
     description = ''
 
 dependencies = ['gaiatest-v2.0',
-                'fxapom == 1.0']
+                'fxapom']
 
 setup(name='marketplacetests',
       version='1.0',


### PR DESCRIPTION
This will mean we won't need to update this project every time fxapom is updated

`fxapom` was also to pick up a new version of `PyFxA`, so this project needs to be updated to pick up the new `fxapom`. I think it makes sense to unpin `fxapom` as only this project and marketplace-tests (desktop tests) use it, and we are in full control of all 3 projects.

@davehunt r?