### PR TITLE
Fix failing in app payments tests

### DIFF
--- a/marketplacetests/in_app_payments/in_app.py
+++ b/marketplacetests/in_app_payments/in_app.py
@@ -2,29 +2,39 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marionette.by import By
+from marionette import expected, By, Wait
 from gaiatest.apps.base import Base
 
 
 class InAppPayment(Base):
 
     # Products
-    _buy_product_button_locator = (By.CSS_SELECTOR, '.item > button')
     _bought_product_locator = (By.CSS_SELECTOR, '#bought .item > h4')
+    _buy_product_button_locator = (By.XPATH, "//h4[text()='%s']/following-sibling::button")
+    _server_select_locator = (By.ID, 'server')
 
-    def __init__(self, marionette):
+    def __init__(self, marionette, server):
         Base.__init__(self, marionette)
         self.apps.switch_to_displayed_app()
-
-    def tap_buy_product(self):
-        self.wait_for_element_displayed(*self._buy_product_button_locator)
-        self.marionette.find_element(*self._buy_product_button_locator).tap()
-        from marketplacetests.firefox_accounts.app import FirefoxAccounts
-        return FirefoxAccounts(self.marionette)
+        self.set_server('API: %s' % server)
 
     @property
     def bought_product_text(self):
         return self.marionette.find_element(*self._bought_product_locator).text
+
+    def set_server(self, server):
+        element = self.marionette.find_element(*self._server_select_locator)
+        element.tap()
+        self.select(server)
+        self.apps.switch_to_displayed_app()
+
+    def tap_buy_product(self, text):
+        element = Wait(self.marionette).until(
+            expected.element_present(self._buy_product_button_locator[0], self._buy_product_button_locator[1] % text))
+        Wait(self.marionette).until(expected.element_displayed(element))
+        element.tap()
+        from marketplacetests.firefox_accounts.app import FirefoxAccounts
+        return FirefoxAccounts(self.marionette)
 
     def wait_for_bought_products_displayed(self):
         self.wait_for_element_displayed(*self._bought_product_locator)

--- a/marketplacetests/in_app_payments/in_app.py
+++ b/marketplacetests/in_app_payments/in_app.py
@@ -2,21 +2,27 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marionette import expected, By, Wait
 from gaiatest.apps.base import Base
+from gaiatest.apps.base import PageRegion
+from marionette import expected, By, Wait
+
+from marketplacetests.firefox_accounts.app import FirefoxAccounts
 
 
-class InAppPayment(Base):
+class InAppPaymentTester(Base):
+
+    default_server = 'API: marketplace-dev.allizom.org'
 
     # Products
+    _available_products_locator = (By.ID, 'items')
+    _available_product_locator = (By.CSS_SELECTOR, '#items li')
     _bought_product_locator = (By.CSS_SELECTOR, '#bought .item > h4')
-    _buy_product_button_locator = (By.XPATH, "//h4[text()='%s']/following-sibling::button")
     _server_select_locator = (By.ID, 'server')
 
-    def __init__(self, marionette, server):
+    def __init__(self, marionette, server=default_server):
         Base.__init__(self, marionette)
         self.apps.switch_to_displayed_app()
-        self.set_server('API: %s' % server)
+        self.set_server(server)
 
     @property
     def bought_product_text(self):
@@ -28,13 +34,35 @@ class InAppPayment(Base):
         self.select(server)
         self.apps.switch_to_displayed_app()
 
-    def tap_buy_product(self, text):
-        element = Wait(self.marionette).until(
-            expected.element_present(self._buy_product_button_locator[0], self._buy_product_button_locator[1] % text))
-        Wait(self.marionette).until(expected.element_displayed(element))
-        element.tap()
-        from marketplacetests.firefox_accounts.app import FirefoxAccounts
-        return FirefoxAccounts(self.marionette)
+    def tap_buy_product(self, name):
+        for product in self.available_products:
+            if product.name == name:
+                product.tap_buy_button()
+                return FirefoxAccounts(self.marionette)
+        raise Exception('Unable to find and tap on product %s.'
+                        % name)
 
     def wait_for_bought_products_displayed(self):
         self.wait_for_element_displayed(*self._bought_product_locator)
+
+    @property
+    def available_products(self):
+        element = Wait(self.marionette).until(
+            expected.element_present(*self._available_products_locator))
+        Wait(self.marionette).until(expected.element_displayed(element))
+        products = self.marionette.find_elements(*self._available_product_locator)
+        Wait(self.marionette).until(lambda m: len(products) > 0)
+        return [Product(self.marionette, product) for product in products]
+
+
+class Product(PageRegion):
+
+    _buy_button_locator = (By.CSS_SELECTOR, 'button')
+    _name_locator = (By.CSS_SELECTOR, 'h4')
+
+    @property
+    def name(self):
+        return self.root_element.find_element(*self._name_locator).text
+
+    def tap_buy_button(self):
+        self.root_element.find_element(*self._buy_button_locator).tap()

--- a/marketplacetests/in_app_payments/in_app.py
+++ b/marketplacetests/in_app_payments/in_app.py
@@ -14,13 +14,16 @@ class InAppPaymentTester(Base):
     default_server = 'API: marketplace-dev.allizom.org'
 
     # Products
-    _available_products_locator = (By.ID, 'items')
     _available_product_locator = (By.CSS_SELECTOR, '#items li')
     _bought_product_locator = (By.CSS_SELECTOR, '#bought .item > h4')
     _server_select_locator = (By.ID, 'server')
 
-    def __init__(self, marionette, server=default_server):
+    def __init__(self, marionette, name):
         Base.__init__(self, marionette)
+        self.name = name
+
+    def launch(self, server=default_server):
+        Base.launch(self, launch_timeout=120000)
         self.apps.switch_to_displayed_app()
         self.set_server(server)
 
@@ -47,11 +50,8 @@ class InAppPaymentTester(Base):
 
     @property
     def available_products(self):
-        element = Wait(self.marionette).until(
-            expected.element_present(*self._available_products_locator))
-        Wait(self.marionette).until(expected.element_displayed(element))
-        products = self.marionette.find_elements(*self._available_product_locator)
-        Wait(self.marionette).until(lambda m: len(products) > 0)
+        products = Wait(self.marionette).until(
+            expected.elements_present(*self._available_product_locator))
         return [Product(self.marionette, product) for product in products]
 
 

--- a/marketplacetests/marketplace_gaia_test.py
+++ b/marketplacetests/marketplace_gaia_test.py
@@ -35,7 +35,7 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
 
         # Remove the app if already installed
         if self.apps.is_app_installed(app_name):
-            self.apps.uninstall(app_name)
+            raise Exception('The app %s is already installed.' % app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()

--- a/marketplacetests/marketplace_gaia_test.py
+++ b/marketplacetests/marketplace_gaia_test.py
@@ -33,17 +33,19 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
 
         homescreen = Homescreen(self.marionette)
 
-        if not self.apps.is_app_installed(app_name):
+        # Remove the app if already installed
+        if self.apps.is_app_installed(app_name):
+            self.apps.uninstall(app_name)
 
-            marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-            home_page = marketplace.launch()
-            details_page = home_page.navigate_to_app(app_name)
-            details_page.tap_install_button()
-            self.wait_for_downloads_to_finish()
+        marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
+        home_page = marketplace.launch()
+        details_page = home_page.navigate_to_app(app_name)
+        details_page.tap_install_button()
+        self.wait_for_downloads_to_finish()
 
-            # Confirm the installation and wait for the app icon to be present
-            confirm_install = ConfirmInstall(self.marionette)
-            confirm_install.tap_confirm()
+        # Confirm the installation and wait for the app icon to be present
+        confirm_install = ConfirmInstall(self.marionette)
+        confirm_install.tap_confirm()
 
         self.device.touch_home_button()
         self.apps.switch_to_displayed_app()

--- a/marketplacetests/marketplace_gaia_test.py
+++ b/marketplacetests/marketplace_gaia_test.py
@@ -29,15 +29,15 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
         # This is used to tell FxA whether to create a dev or prod account
         self.base_url = 'https://marketplace-dev.allizom.org'
 
-    def install_in_app_payments_test_app(self):
+    def install_in_app_payments_test_app(self, app_name):
 
-        self.homescreen = Homescreen(self.marionette)
+        homescreen = Homescreen(self.marionette)
 
-        if not self.apps.is_app_installed(self.app_name):
+        if not self.apps.is_app_installed(app_name):
 
             marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
             home_page = marketplace.launch()
-            details_page = home_page.navigate_to_app(self.app_name)
+            details_page = home_page.navigate_to_app(app_name)
             details_page.tap_install_button()
             self.wait_for_downloads_to_finish()
 
@@ -47,14 +47,8 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
 
         self.device.touch_home_button()
         self.apps.switch_to_displayed_app()
-        self.homescreen.wait_for_app_icon_present(self.app_name)
-
-    def create_account_and_change_its_region(self):
-        self.acct = FxATestAccount(base_url=self.base_url).create_account()
-        marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        home_page = marketplace.launch()
-        settings = home_page.login(self.acct.email, self.acct.password)
-        settings.set_region('United States')
+        homescreen.wait_for_app_icon_present(app_name)
+        return homescreen
 
     @property
     def email(self):

--- a/marketplacetests/payment/app.py
+++ b/marketplacetests/payment/app.py
@@ -114,9 +114,6 @@ class Payment(Marketplace):
     def tap_buy_button(self):
         self._tap_payment_button(self._buy_button_locator)
 
-    def tap_in_app_buy_button(self):
-        self._tap_payment_button(self._buy_button_locator, 'in-app tester')
-
     def tap_forgot_pin(self):
         self.wait_for_element_displayed(*self._forgot_pin_locator)
         self.marionette.find_element(*self._forgot_pin_locator).tap()
@@ -125,6 +122,7 @@ class Payment(Marketplace):
         button = Wait(self.marionette).until(
             expected.element_present(*self._reset_pin_button_locator))
         Wait(self.marionette).until(expected.element_displayed(button))
+        Wait(self.marionette).until(expected.element_enabled(button))
         # This workaround is required for gaia v2.0, but can be removed in later versions
         # as the bug has been fixed
         # Bug 937053 - tap() method should calculate elementInView from the coordinates of the tap
@@ -134,7 +132,7 @@ class Payment(Marketplace):
     def tap_cancel_button(self):
         self._tap_payment_button(self._cancel_button_locator)
 
-    def _tap_payment_button(self, button_locator, return_to='marketplace'):
+    def _tap_payment_button(self, button_locator):
         self.marionette.switch_to_frame()
         self.wait_for_element_not_displayed(*self._loading_throbber_locator)
         payment_iframe = self.marionette.find_element(*self._payment_frame_locator)
@@ -143,7 +141,13 @@ class Payment(Marketplace):
         self.marionette.find_element(*button_locator).tap()
         self.marionette.switch_to_frame()
         self.wait_for_element_not_present(*self._payment_frame_locator)
-        if return_to == 'marketplace':
-            self.switch_to_marketplace_frame()
-        else:
-            self.apps.switch_to_displayed_app()
+        self.return_to_app()
+
+    def return_to_app(self):
+        self.switch_to_marketplace_frame()
+
+
+class InAppPayment(Payment):
+
+    def return_to_app(self):
+        self.apps.switch_to_displayed_app()

--- a/marketplacetests/payment/app.py
+++ b/marketplacetests/payment/app.py
@@ -114,6 +114,9 @@ class Payment(Marketplace):
     def tap_buy_button(self):
         self._tap_payment_button(self._buy_button_locator)
 
+    def tap_in_app_buy_button(self):
+        self._tap_payment_button(self._buy_button_locator, 'in-app tester')
+
     def tap_forgot_pin(self):
         self.wait_for_element_displayed(*self._forgot_pin_locator)
         self.marionette.find_element(*self._forgot_pin_locator).tap()
@@ -131,7 +134,7 @@ class Payment(Marketplace):
     def tap_cancel_button(self):
         self._tap_payment_button(self._cancel_button_locator)
 
-    def _tap_payment_button(self, button_locator):
+    def _tap_payment_button(self, button_locator, return_to='marketplace'):
         self.marionette.switch_to_frame()
         self.wait_for_element_not_displayed(*self._loading_throbber_locator)
         payment_iframe = self.marionette.find_element(*self._payment_frame_locator)
@@ -140,4 +143,7 @@ class Payment(Marketplace):
         self.marionette.find_element(*button_locator).tap()
         self.marionette.switch_to_frame()
         self.wait_for_element_not_present(*self._payment_frame_locator)
-        self.switch_to_marketplace_frame()
+        if return_to == 'marketplace':
+            self.switch_to_marketplace_frame()
+        else:
+            self.apps.switch_to_displayed_app()

--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -17,7 +17,7 @@ offline = false
 
 [test_marketplace_incorrect_pin.py]
 
-[test_marketplace_in_app_not_you_login_feature.py]
+[test_marketplace_in_app_not_you_logout_feature.py]
 
 [test_marketplace_login.py]
 

--- a/marketplacetests/tests/test_marketplace_in_app_not_you_login_feature.py
+++ b/marketplacetests/tests/test_marketplace_in_app_not_you_login_feature.py
@@ -6,8 +6,8 @@ from marionette import Wait
 from fxapom.fxapom import FxATestAccount
 
 from marketplacetests.firefox_accounts.app import FirefoxAccounts
-from marketplacetests.payment.app import Payment
-from marketplacetests.in_app_payments.in_app import InAppPayment
+from marketplacetests.payment.app import InAppPayment
+from marketplacetests.in_app_payments.in_app import InAppPaymentTester
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 
 
@@ -16,7 +16,6 @@ class TestNotYouLinkInAppPayment(MarketplaceGaiaTestCase):
     test_data = {
         'app_name': 'Testing In-App-Payments',
         'app_title': 'In-App-Payments',
-        'server': 'marketplace-dev.allizom.org',
         'product': 'test 0.99 USD'}
 
     def test_not_you_link_in_app_payment(self):
@@ -34,11 +33,11 @@ class TestNotYouLinkInAppPayment(MarketplaceGaiaTestCase):
 
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        tester_app = InAppPayment(self.marionette, self.test_data['server'])
+        tester_app = InAppPaymentTester(self.marionette)
         fxa = tester_app.tap_buy_product(self.test_data['product'])
         fxa.login(acct.email, acct.password)
 
-        payment = Payment(self.marionette)
+        payment = InAppPayment(self.marionette)
         payment.tap_cancel_pin()
 
         fxa = tester_app.tap_buy_product(self.test_data['product'])

--- a/marketplacetests/tests/test_marketplace_in_app_not_you_login_feature.py
+++ b/marketplacetests/tests/test_marketplace_in_app_not_you_login_feature.py
@@ -13,33 +13,35 @@ from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 
 class TestNotYouLinkInAppPayment(MarketplaceGaiaTestCase):
 
+    test_data = {
+        'app_name': 'Testing In-App-Payments',
+        'app_title': 'In-App-Payments',
+        'server': 'marketplace-dev.allizom.org',
+        'product': 'test 0.99 USD'}
+
     def test_not_you_link_in_app_payment(self):
 
-        self.app_name = 'Testing In-App-Payments'
-        app_title = 'In-App-Payments'
-
-        self.install_in_app_payments_test_app()
+        homescreen = self.install_in_app_payments_test_app(self.test_data['app_name'])
 
         # Verify that the app icon is visible on one of the homescreen pages
         self.assertTrue(
-            self.homescreen.is_app_installed(self.app_name),
-            'App %s not found on homescreen' % self.app_name)
+            homescreen.is_app_installed(self.test_data['app_name']),
+            'App %s not found on homescreen' % self.test_data['app_name'])
 
         # Click icon and wait for h1 element displayed
-        self.homescreen.installed_app(self.app_name).tap_icon()
-        Wait(self.marionette).until(lambda m: m.title == app_title)
+        homescreen.installed_app(self.test_data['app_name']).tap_icon()
+        Wait(self.marionette).until(lambda m: m.title == self.test_data['app_title'])
 
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        tester_app = InAppPayment(self.marionette)
-        fxa = tester_app.tap_buy_product()
+        tester_app = InAppPayment(self.marionette, self.test_data['server'])
+        fxa = tester_app.tap_buy_product(self.test_data['product'])
         fxa.login(acct.email, acct.password)
 
         payment = Payment(self.marionette)
         payment.tap_cancel_pin()
 
-        tester_app.tap_buy_product()
-        fxa = FirefoxAccounts(self.marionette)
+        fxa = tester_app.tap_buy_product(self.test_data['product'])
         self.assertTrue(fxa.is_not_you_logout_link_visible)
         self.assertEqual('You are signed in as: %s' % acct.email, 'You are signed in as: %s' % fxa.email_text)
 

--- a/marketplacetests/tests/test_marketplace_in_app_not_you_logout_feature.py
+++ b/marketplacetests/tests/test_marketplace_in_app_not_you_logout_feature.py
@@ -5,21 +5,21 @@
 from marionette import Wait
 from fxapom.fxapom import FxATestAccount
 
-from marketplacetests.firefox_accounts.app import FirefoxAccounts
 from marketplacetests.payment.app import InAppPayment
 from marketplacetests.in_app_payments.in_app import InAppPaymentTester
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 
 
-class TestNotYouLinkInAppPayment(MarketplaceGaiaTestCase):
+class TestNotYouLogoutFromInAppPayment(MarketplaceGaiaTestCase):
 
     test_data = {
         'app_name': 'Testing In-App-Payments',
         'app_title': 'In-App-Payments',
         'product': 'test 0.99 USD'}
 
-    def test_not_you_link_in_app_payment(self):
+    def test_not_you_logout_from_in_app_payment(self):
 
+        acct = FxATestAccount(base_url=self.base_url).create_account()
         homescreen = self.install_in_app_payments_test_app(self.test_data['app_name'])
 
         # Verify that the app icon is visible on one of the homescreen pages
@@ -27,22 +27,23 @@ class TestNotYouLinkInAppPayment(MarketplaceGaiaTestCase):
             homescreen.is_app_installed(self.test_data['app_name']),
             'App %s not found on homescreen' % self.test_data['app_name'])
 
-        # Click icon and wait for h1 element displayed
-        homescreen.installed_app(self.test_data['app_name']).tap_icon()
+        self.tester_app = InAppPaymentTester(self.marionette, self.test_data['app_name'])
+        self.tester_app.launch()
         Wait(self.marionette).until(lambda m: m.title == self.test_data['app_title'])
 
-        acct = FxATestAccount(base_url=self.base_url).create_account()
-
-        tester_app = InAppPaymentTester(self.marionette)
-        fxa = tester_app.tap_buy_product(self.test_data['product'])
+        fxa = self.tester_app.tap_buy_product(self.test_data['product'])
         fxa.login(acct.email, acct.password)
 
         payment = InAppPayment(self.marionette)
         payment.tap_cancel_pin()
 
-        fxa = tester_app.tap_buy_product(self.test_data['product'])
+        fxa = self.tester_app.tap_buy_product(self.test_data['product'])
         self.assertTrue(fxa.is_not_you_logout_link_visible)
         self.assertEqual('You are signed in as: %s' % acct.email, 'You are signed in as: %s' % fxa.email_text)
 
         fxa.tap_not_you()
         fxa.wait_for_password_field_visible()
+
+    def tearDown(self):
+        self.apps.uninstall(self.test_data['app_name'])
+        MarketplaceGaiaTestCase.tearDown(self)

--- a/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
+++ b/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
@@ -5,8 +5,8 @@
 from fxapom.fxapom import FxATestAccount
 from marionette import Wait
 
-from marketplacetests.in_app_payments.in_app import InAppPayment
-from marketplacetests.payment.app import Payment
+from marketplacetests.in_app_payments.in_app import InAppPaymentTester
+from marketplacetests.payment.app import InAppPayment
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 
 
@@ -15,7 +15,6 @@ class TestMakeInAppPayment(MarketplaceGaiaTestCase):
     test_data = {
         'app_name': 'Testing In-App-Payments',
         'app_title': 'In-App-Payments',
-        'server': 'marketplace-dev.allizom.org',
         'pin': '1234',
         'product': 'test 0.99 USD'}
 
@@ -34,17 +33,17 @@ class TestMakeInAppPayment(MarketplaceGaiaTestCase):
 
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        tester_app = InAppPayment(self.marionette, self.test_data['server'])
+        tester_app = InAppPaymentTester(self.marionette)
         fxa = tester_app.tap_buy_product(self.test_data['product'])
         fxa.login(acct.email, acct.password)
 
-        payment = Payment(self.marionette)
+        payment = InAppPayment(self.marionette)
         payment.create_pin(self.test_data['pin'])
 
         self.assertEqual('Confirm Payment', payment.confirm_payment_header_text)
         self.assertEqual(self.test_data['product'], payment.in_app_product_name)
 
-        payment.tap_in_app_buy_button()
+        payment.tap_buy_button()
         # self.apps.switch_to_displayed_app()
         tester_app.wait_for_bought_products_displayed()
         self.assertEqual(self.test_data['product'], tester_app.bought_product_text)


### PR DESCRIPTION
This fixes the tests for in-app payments that have been failing since last week. Both in-app tests (`test_make_an_in_app_payment` and `test_not_you_link_in_app_payment`) have been failing.