### PR TITLE
Refactor tests to make page flow more explicit and to add waits for pages to be ready

### DIFF
--- a/marketplacetests/marketplace/app.py
+++ b/marketplacetests/marketplace/app.py
@@ -41,8 +41,7 @@ class Marketplace(Base):
         if expect_success:
             self.switch_to_marketplace_frame()
             from marketplacetests.marketplace.regions.home import Home
-            home_page = Home(self.marionette)
-            return home_page
+            return Home(self.marionette)
 
     def switch_to_marketplace_frame(self):
         self.marionette.switch_to_frame()
@@ -87,12 +86,10 @@ class Marketplace(Base):
         return self.marionette.find_element(*self._notification_locator).text
 
     def _perform_search(self, term):
-        self.wait_for_page_loaded()
         search_box = Wait(self.marionette).until(
             expected.element_present(*self._search_locator))
         Wait(self.marionette).until(expected.element_displayed(search_box))
         search_box.send_keys(term)
-
         search_box.send_keys(Keys.RETURN)
 
     def search(self, term):
@@ -112,6 +109,7 @@ class Marketplace(Base):
                             % (region, self.notification_message))
 
         debug_screen.tap_back()
+        self.wait_for_page_loaded()
 
     def navigate_to_app(self, app_name):
         search_results = self.search(app_name).search_results

--- a/marketplacetests/marketplace/app.py
+++ b/marketplacetests/marketplace/app.py
@@ -19,7 +19,6 @@ class Marketplace(Base):
     _offline_message_locator = (By.CSS_SELECTOR, 'div.error-message[data-l10n="offline"]')
     _settings_button_locator = (By.CSS_SELECTOR, '.act-tray.active .header-button.settings')
     _home_button_locator = (By.CSS_SELECTOR, 'h1.site a')
-    _back_button_locator = (By.ID, 'nav-back')
     _notification_locator = (By.ID, 'notification-content')
 
     # Marketplace search on home page
@@ -128,9 +127,6 @@ class Marketplace(Base):
 
     def tap_home(self):
         self.marionette.find_element(*self._home_button_locator).tap()
-
-    def tap_back(self):
-        self.marionette.find_element(*self._back_button_locator).tap()
 
     @property
     def install_notification_message(self):

--- a/marketplacetests/marketplace/regions/add_review.py
+++ b/marketplacetests/marketplace/regions/add_review.py
@@ -3,22 +3,24 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette.by import By
-from gaiatest.apps.base import Base
 
+from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.app_details import Details
 
-class AddReview(Base):
+class AddReview(Marketplace):
     """
     Page for adding reviews.
     """
 
+    _page_loaded_locator = (By.CSS_SELECTOR, 'form.add-review-form')
+
     _add_review_input_field_locator = (By.ID, 'review-body')
     _submit_review_button_locator = (By.CSS_SELECTOR, 'button[type="submit"]')
-    _review_box_locator = (By.CSS_SELECTOR, '.add-review-form')
     _rating_locator = (By.CSS_SELECTOR, ".ratingwidget.stars-0 > label[data-stars='%s']")
 
     def __init__(self, marionette):
-        Base.__init__(self, marionette)
-        self.wait_for_element_displayed(*self._review_box_locator)
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()
 
     def set_review_rating(self, rating):
         self.marionette.find_element(self._rating_locator[0], self._rating_locator[1] % rating).tap()
@@ -30,3 +32,4 @@ class AddReview(Base):
         self.set_review_rating(rating)
         self.type_review(body)
         self.marionette.find_element(*self._submit_review_button_locator).tap()
+        return Details(self.marionette)

--- a/marketplacetests/marketplace/regions/add_review.py
+++ b/marketplacetests/marketplace/regions/add_review.py
@@ -4,10 +4,11 @@
 
 from marionette.by import By
 
-from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.base_region import BaseRegion
 from marketplacetests.marketplace.regions.app_details import Details
 
-class AddReview(Marketplace):
+
+class AddReview(BaseRegion):
     """
     Page for adding reviews.
     """
@@ -17,10 +18,6 @@ class AddReview(Marketplace):
     _add_review_input_field_locator = (By.ID, 'review-body')
     _submit_review_button_locator = (By.CSS_SELECTOR, 'button[type="submit"]')
     _rating_locator = (By.CSS_SELECTOR, ".ratingwidget.stars-0 > label[data-stars='%s']")
-
-    def __init__(self, marionette):
-        Marketplace.__init__(self, marionette)
-        self.wait_for_page_loaded()
 
     def set_review_rating(self, rating):
         self.marionette.find_element(self._rating_locator[0], self._rating_locator[1] % rating).tap()

--- a/marketplacetests/marketplace/regions/app_details.py
+++ b/marketplacetests/marketplace/regions/app_details.py
@@ -3,10 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette.by import By
-from gaiatest.apps.base import Base
+
+from marketplacetests.marketplace.app import Marketplace
 
 
-class Details(Base):
+class Details(Marketplace):
+
+    _page_loaded_locator = (By.CSS_SELECTOR, 'section.app-reviews')
 
     _write_review_locator = (By.CSS_SELECTOR, 'a.review-button')
     _app_info_locator = (By.CSS_SELECTOR, '.detail .info')
@@ -15,8 +18,8 @@ class Details(Base):
     _install_button_locator = (By.CSS_SELECTOR, '.detail .info button.product.install')
 
     def __init__(self, marionette):
-        Base.__init__(self, marionette)
-        self.wait_for_element_present(*self._app_info_locator)
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()
 
     @property
     def is_app_details_displayed(self):
@@ -42,7 +45,7 @@ class Details(Base):
             from marketplacetests.firefox_accounts.app import FirefoxAccounts
             return FirefoxAccounts(self.marionette)
         else:
-            from marketplacetests.marketplace.regions.review_box import AddReview
+            from marketplacetests.marketplace.regions.add_review import AddReview
             return AddReview(self.marionette)
 
     def tap_install_button(self):

--- a/marketplacetests/marketplace/regions/app_details.py
+++ b/marketplacetests/marketplace/regions/app_details.py
@@ -4,10 +4,10 @@
 
 from marionette.by import By
 
-from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.base_region import BaseRegion
 
 
-class Details(Marketplace):
+class Details(BaseRegion):
 
     _page_loaded_locator = (By.CSS_SELECTOR, 'section.app-reviews')
 
@@ -16,10 +16,6 @@ class Details(Marketplace):
     _first_review_locator = (By.CSS_SELECTOR, '.reviews-wrapper li:first-child')
     _first_review_body_locator = (By.CSS_SELECTOR, '.reviews-wrapper .review-body')
     _install_button_locator = (By.CSS_SELECTOR, '.detail .info button.product.install')
-
-    def __init__(self, marionette):
-        Marketplace.__init__(self, marionette)
-        self.wait_for_page_loaded()
 
     @property
     def is_app_details_displayed(self):

--- a/marketplacetests/marketplace/regions/base_region.py
+++ b/marketplacetests/marketplace/regions/base_region.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marketplacetests.marketplace.app import Marketplace
+
+
+class BaseRegion(Marketplace):
+
+    def __init__(self, marionette):
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()

--- a/marketplacetests/marketplace/regions/debug.py
+++ b/marketplacetests/marketplace/regions/debug.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from gaiatest.apps.base import Base
 from marionette.by import By
 
 from marketplacetests.marketplace.app import Marketplace
@@ -10,12 +9,14 @@ from marketplacetests.marketplace.app import Marketplace
 
 class Debug(Marketplace):
 
+    _page_loaded_locator = (By.CSS_SELECTOR, 'section.debug')
+
     _back_button_locator = (By.ID, 'nav-back')
     _region_select_locator = (By.ID, 'debug-region')
 
     def __init__(self, marionette):
-        Base.__init__(self, marionette)
-        self.wait_for_element_displayed(*self._region_select_locator)
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()
 
     def tap_back(self):
         self.marionette.find_element(*self._back_button_locator).tap()

--- a/marketplacetests/marketplace/regions/debug.py
+++ b/marketplacetests/marketplace/regions/debug.py
@@ -4,19 +4,15 @@
 
 from marionette.by import By
 
-from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.base_region import BaseRegion
 
 
-class Debug(Marketplace):
+class Debug(BaseRegion):
 
     _page_loaded_locator = (By.CSS_SELECTOR, 'section.debug')
 
     _back_button_locator = (By.ID, 'nav-back')
     _region_select_locator = (By.ID, 'debug-region')
-
-    def __init__(self, marionette):
-        Marketplace.__init__(self, marionette)
-        self.wait_for_page_loaded()
 
     def tap_back(self):
         self.marionette.find_element(*self._back_button_locator).tap()

--- a/marketplacetests/marketplace/regions/debug.py
+++ b/marketplacetests/marketplace/regions/debug.py
@@ -11,7 +11,7 @@ class Debug(BaseRegion):
 
     _page_loaded_locator = (By.CSS_SELECTOR, 'section.debug')
 
-    _back_button_locator = (By.ID, 'nav-back')
+    _back_button_locator = (By.CSS_SELECTOR, '#site-header a.header-button.back')
     _region_select_locator = (By.ID, 'debug-region')
 
     def tap_back(self):

--- a/marketplacetests/marketplace/regions/home.py
+++ b/marketplacetests/marketplace/regions/home.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette.by import By
+
+from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.search_results import Result
+
+
+class Home(Marketplace):
+
+    _page_loaded_locator = (By.CSS_SELECTOR, 'div.feed-home')
+
+    _popular_apps_tab_locator = (By.CSS_SELECTOR, 'a[href="/popular"]')
+
+    def __init__(self, marionette):
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()
+
+    @property
+    def popular_apps_page(self):
+        self.wait_for_element_displayed(*self._popular_apps_tab_locator)
+        self.marionette.find_element(*self._popular_apps_tab_locator).tap()
+        return PopularApps(self.marionette)
+
+
+class PopularApps(Marketplace):
+
+    _page_loaded_locator = (By.CSS_SELECTOR, 'ul.app-list')
+
+    _gallery_apps_locator = (By.CSS_SELECTOR, '.app-list-app')
+
+    def __init__(self, marionette):
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()
+
+    @property
+    def popular_apps(self):
+        return [Result(self.marionette, app) for app in self.marionette.find_elements(*self._gallery_apps_locator)]

--- a/marketplacetests/marketplace/regions/home.py
+++ b/marketplacetests/marketplace/regions/home.py
@@ -4,19 +4,15 @@
 
 from marionette.by import By
 
-from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.base_region import BaseRegion
 from marketplacetests.marketplace.regions.search_results import Result
 
 
-class Home(Marketplace):
+class Home(BaseRegion):
 
     _page_loaded_locator = (By.CSS_SELECTOR, 'div.feed-home')
 
     _popular_apps_tab_locator = (By.CSS_SELECTOR, 'a[href="/popular"]')
-
-    def __init__(self, marionette):
-        Marketplace.__init__(self, marionette)
-        self.wait_for_page_loaded()
 
     @property
     def popular_apps_page(self):
@@ -25,15 +21,11 @@ class Home(Marketplace):
         return PopularApps(self.marionette)
 
 
-class PopularApps(Marketplace):
+class PopularApps(BaseRegion):
 
     _page_loaded_locator = (By.CSS_SELECTOR, 'ul.app-list')
 
     _gallery_apps_locator = (By.CSS_SELECTOR, '.app-list-app')
-
-    def __init__(self, marionette):
-        Marketplace.__init__(self, marionette)
-        self.wait_for_page_loaded()
 
     @property
     def popular_apps(self):

--- a/marketplacetests/marketplace/regions/search_results.py
+++ b/marketplacetests/marketplace/regions/search_results.py
@@ -3,25 +3,28 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette.by import By
-from gaiatest.apps.base import Base
 from gaiatest.apps.base import PageRegion
 
+from marketplacetests.marketplace.app import Marketplace
 
-class SearchResults(Base):
+
+class SearchResults(Marketplace):
+
+    _page_loaded_locator = (By.CSS_SELECTOR, 'ul.app-list')
 
     _search_results_area_locator = (By.ID, 'search-results')
-    _search_results_loading_locator = (By.CSS_SELECTOR, 'div.loading')
     _search_result_locator = (By.CSS_SELECTOR, '#search-results li.item')
 
     def __init__(self, marionette):
-        Base.__init__(self, marionette)
-        self.wait_for_element_not_present(*self._search_results_loading_locator)
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()
 
     @property
     def search_results(self):
         self.wait_for_element_displayed(*self._search_result_locator)
         search_results = self.marionette.find_elements(*self._search_result_locator)
         return [Result(self.marionette, result) for result in search_results]
+
 
 class Result(PageRegion):
 

--- a/marketplacetests/marketplace/regions/search_results.py
+++ b/marketplacetests/marketplace/regions/search_results.py
@@ -5,19 +5,15 @@
 from marionette.by import By
 from gaiatest.apps.base import PageRegion
 
-from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.base_region import BaseRegion
 
 
-class SearchResults(Marketplace):
+class SearchResults(BaseRegion):
 
     _page_loaded_locator = (By.CSS_SELECTOR, 'ul.app-list')
 
     _search_results_area_locator = (By.ID, 'search-results')
     _search_result_locator = (By.CSS_SELECTOR, '#search-results li.item')
-
-    def __init__(self, marionette):
-        Marketplace.__init__(self, marionette)
-        self.wait_for_page_loaded()
 
     @property
     def search_results(self):

--- a/marketplacetests/marketplace/regions/settings.py
+++ b/marketplacetests/marketplace/regions/settings.py
@@ -3,10 +3,20 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette.by import By
-from gaiatest.apps.base import Base
+
+from marketplacetests.marketplace.app import Marketplace
 
 
-class Settings(Base):
+class Settings(Marketplace):
+
+    _page_loaded_locator = (By.CSS_SELECTOR, 'form.account-settings')
+
+    # Marketplace settings tabs
+    _account_tab_locator = (By.CSS_SELECTOR, 'a[href="/settings"]')
+    _my_apps_tab_locator = (By.CSS_SELECTOR, 'a[href="/purchases"]')
+    _feedback_tab_locator = (By.CSS_SELECTOR, 'a[href="/feedback"]')
+    _feedback_textarea_locator = (By.NAME, 'feedback')
+    _feedback_submit_button_locator = (By.CSS_SELECTOR, 'button[type="submit"]')
 
     _email_locator = (By.CSS_SELECTOR, '.email.account-field > p')
     _save_locator = (By.CSS_SELECTOR, 'footer > p > button')
@@ -19,8 +29,9 @@ class Settings(Base):
     _login_required_message_locator = (By.CSS_SELECTOR, '.only-logged-out .notice')
 
     def __init__(self, marionette):
-        Base.__init__(self, marionette)
-        self.wait_for_element_displayed(*self._sign_in_button_locator)
+        Marketplace.__init__(self, marionette)
+        self.wait_for_page_loaded()
+        self.wait_for_sign_in_displayed()
 
     def tap_back(self):
         self.marionette.find_element(*self._back_button_locator).tap()
@@ -58,8 +69,27 @@ class Settings(Base):
         self.marionette.find_element(*self._my_apps_tab_locator).tap()
         return MyApps(self.marionette)
 
+    def select_setting_feedback(self):
+        self.marionette.find_element(*self._feedback_tab_locator).tap()
 
-class MyApps(Base):
+    def select_setting_account(self):
+        self.marionette.find_element(*self._account_tab_locator).tap()
+
+    def select_setting_my_apps(self):
+        self.marionette.find_element(*self._my_apps_tab_locator).tap()
+
+    def enter_feedback(self, feedback_text):
+        feedback = self.marionette.find_element(*self._feedback_textarea_locator)
+        feedback.clear()
+        feedback.send_keys(feedback_text)
+        self.switch_to_marketplace_frame()
+
+    def submit_feedback(self):
+        self.wait_for_element_displayed(*self._feedback_submit_button_locator)
+        self.marionette.find_element(*self._feedback_submit_button_locator).tap()
+
+
+class MyApps(Marketplace):
 
     _login_required_message_locator = (By.CSS_SELECTOR, '#account-settings .main div p')
     _my_apps_list_locator = (By.CSS_SELECTOR, '.item.result')

--- a/marketplacetests/marketplace/regions/settings.py
+++ b/marketplacetests/marketplace/regions/settings.py
@@ -4,10 +4,10 @@
 
 from marionette.by import By
 
-from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.regions.base_region import BaseRegion
 
 
-class Settings(Marketplace):
+class Settings(BaseRegion):
 
     _page_loaded_locator = (By.CSS_SELECTOR, 'form.account-settings')
 
@@ -28,15 +28,10 @@ class Settings(Marketplace):
     _my_apps_tab_locator = (By.CSS_SELECTOR, '.tab-link[href="/purchases"]')
     _login_required_message_locator = (By.CSS_SELECTOR, '.only-logged-out .notice')
 
-    def __init__(self, marionette):
-        Marketplace.__init__(self, marionette)
-        self.wait_for_page_loaded()
-        self.wait_for_sign_in_displayed()
-
     def tap_back(self):
         self.marionette.find_element(*self._back_button_locator).tap()
-        from marketplacetests.marketplace.app import Marketplace
-        return Marketplace(self.marionette)
+        from marketplacetests.marketplace.regions.home import Home
+        return Home(self.marionette)
 
     def wait_for_sign_in_displayed(self):
         self.wait_for_element_displayed(*self._sign_in_button_locator)
@@ -89,7 +84,7 @@ class Settings(Marketplace):
         self.marionette.find_element(*self._feedback_submit_button_locator).tap()
 
 
-class MyApps(Marketplace):
+class MyApps(Settings):
 
     _login_required_message_locator = (By.CSS_SELECTOR, '#account-settings .main div p')
     _my_apps_list_locator = (By.CSS_SELECTOR, '.item.result')

--- a/marketplacetests/marketplace/regions/settings.py
+++ b/marketplacetests/marketplace/regions/settings.py
@@ -23,15 +23,9 @@ class Settings(BaseRegion):
     _sign_in_button_on_my_apps_locator = (By.CSS_SELECTOR, '#account-settings a.button.persona:not(.register)')
     _sign_in_button_locator = (By.CSS_SELECTOR, 'a.button.login')
     _sign_out_button_locator = (By.CSS_SELECTOR, 'a.button.logout')
-    _back_button_locator = (By.ID, 'nav-back')
     _save_changes_button_locator = (By.XPATH, "//section[@id='account-settings']//button[text()='Save Changes']")
     _my_apps_tab_locator = (By.CSS_SELECTOR, '.tab-link[href="/purchases"]')
     _login_required_message_locator = (By.CSS_SELECTOR, '.only-logged-out .notice')
-
-    def tap_back(self):
-        self.marionette.find_element(*self._back_button_locator).tap()
-        from marketplacetests.marketplace.regions.home import Home
-        return Home(self.marionette)
 
     def wait_for_sign_in_displayed(self):
         self.wait_for_element_displayed(*self._sign_in_button_locator)

--- a/marketplacetests/marketplace_gaia_test.py
+++ b/marketplacetests/marketplace_gaia_test.py
@@ -33,11 +33,11 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
 
         self.homescreen = Homescreen(self.marionette)
 
-        if not self.apps.is_app_installed(self.APP_NAME):
+        if not self.apps.is_app_installed(self.app_name):
 
             marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-            marketplace.launch()
-            details_page = marketplace.navigate_to_app(self.APP_NAME)
+            home_page = marketplace.launch()
+            details_page = marketplace.navigate_to_app(self.app_name)
             details_page.tap_install_button()
             self.wait_for_downloads_to_finish()
 
@@ -47,14 +47,14 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
 
         self.device.touch_home_button()
         self.apps.switch_to_displayed_app()
-        self.homescreen.wait_for_app_icon_present(self.APP_NAME)
+        self.homescreen.wait_for_app_icon_present(self.app_name)
 
     def create_account_and_change_its_region(self):
         self.acct = FxATestAccount(base_url=self.base_url).create_account()
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
-        marketplace.login(self.acct.email, self.acct.password)
-        marketplace.set_region('United States')
+        home_page = marketplace.launch()
+        settings = marketplace.login(self.acct.email, self.acct.password)
+        settings.set_region('United States')
 
     @property
     def email(self):

--- a/marketplacetests/marketplace_gaia_test.py
+++ b/marketplacetests/marketplace_gaia_test.py
@@ -37,7 +37,7 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
 
             marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
             home_page = marketplace.launch()
-            details_page = marketplace.navigate_to_app(self.app_name)
+            details_page = home_page.navigate_to_app(self.app_name)
             details_page.tap_install_button()
             self.wait_for_downloads_to_finish()
 
@@ -53,7 +53,7 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
         self.acct = FxATestAccount(base_url=self.base_url).create_account()
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
-        settings = marketplace.login(self.acct.email, self.acct.password)
+        settings = home_page.login(self.acct.email, self.acct.password)
         settings.set_region('United States')
 
     @property

--- a/marketplacetests/tests/test_marketplace_add_review.py
+++ b/marketplacetests/tests/test_marketplace_add_review.py
@@ -17,23 +17,24 @@ class TestMarketplaceAddReview(MarketplaceGaiaTestCase):
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        app_name = marketplace.popular_apps[0].name
+        popular_apps_page = home_page.popular_apps_page
+        app_name = popular_apps_page.popular_apps[0].name
 
-        marketplace.login(acct.email, acct.password)
-        details_page = marketplace.navigate_to_app(app_name)
+        settings = popular_apps_page.login(acct.email, acct.password)
+        details_page = settings.navigate_to_app(app_name)
 
         current_time = str(time.time()).split('.')[0]
         rating = random.randint(1, 5)
         body = 'This is a test %s' % current_time
 
-        review_box = details_page.tap_write_review()
-        review_box.write_a_review(rating, body)
+        review_page = details_page.tap_write_review()
+        details_page = review_page.write_a_review(rating, body)
 
-        marketplace.wait_for_notification_message_displayed()
+        details_page.wait_for_notification_message_displayed()
 
         # Check if review was added correctly
-        self.assertEqual(marketplace.notification_message, "Your review was successfully posted. Thanks!")
+        self.assertEqual(details_page.notification_message, "Your review was successfully posted. Thanks!")
         self.assertEqual(details_page.first_review_rating, rating)
         self.assertEqual(details_page.first_review_body, body)

--- a/marketplacetests/tests/test_marketplace_create_confirm_pin.py
+++ b/marketplacetests/tests/test_marketplace_create_confirm_pin.py
@@ -13,24 +13,24 @@ class TestMarketplaceCreateConfirmPin(MarketplaceGaiaTestCase):
 
     def test_create_confirm_pin(self):
 
-        APP_NAME = 'Test Zippy With Me'
-        PIN = '1234'
+        app_name = 'Test Zippy With Me'
+        pin = '1234'
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        if self.apps.is_app_installed(APP_NAME):
-            self.apps.uninstall(APP_NAME)
+        if self.apps.is_app_installed(app_name):
+            self.apps.uninstall(app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        marketplace.login(acct.email, acct.password)
+        settings = home_page.login(acct.email, acct.password)
 
-        marketplace.set_region('United States')
+        settings.set_region('United States')
 
-        details_page = marketplace.navigate_to_app(APP_NAME)
+        details_page = settings.navigate_to_app(app_name)
         details_page.tap_install_button()
 
         payment = Payment(self.marionette)
-        payment.create_pin(PIN)
+        payment.create_pin(pin)
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(APP_NAME, payment.app_name)
+        self.assertIn(app_name, payment.app_name)

--- a/marketplacetests/tests/test_marketplace_feedback_anonymous.py
+++ b/marketplacetests/tests/test_marketplace_feedback_anonymous.py
@@ -7,26 +7,22 @@ from marketplacetests.marketplace.app import Marketplace
 
 
 class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
-    feedback_submitted_message = u'Feedback submitted. Thanks!'
-    test_comment = 'This is a test comment.'
 
     def test_marketplace_feedback_anonymous(self):
+        feedback_submitted_message = u'Feedback submitted. Thanks!'
+        test_comment = 'This is a test comment.'
 
         # launch marketplace dev and go to marketplace
-        self.marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        self.marketplace.launch()
+        marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
+        home_page = marketplace.launch()
 
         # go to settings page
-        self.marketplace.tap_settings()
-        self.marketplace.select_setting_feedback()
+        settings = home_page.tap_settings()
+        settings.select_setting_feedback()
 
         # enter and submit your feedback
-        self.marketplace.enter_feedback(self.test_comment)
-        self.marketplace.submit_feedback()
+        settings.enter_feedback(test_comment)
+        settings.submit_feedback()
 
-        # catch the notification
-        self.marketplace.wait_for_notification_message_displayed()
-        message_content = self.marketplace.notification_message
-
-        # verify if the notification is right
-        self.assertEqual(message_content, self.feedback_submitted_message)
+        # wait for the notification
+        settings.wait_for_notification_message_displayed(feedback_submitted_message)

--- a/marketplacetests/tests/test_marketplace_feedback_login.py
+++ b/marketplacetests/tests/test_marketplace_feedback_login.py
@@ -8,27 +8,24 @@ from marketplacetests.marketplace.app import Marketplace
 
 
 class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
-    feedback_submitted_message = u'Feedback submitted. Thanks!'
-    test_comment = 'This is a test comment.'
 
     def test_marketplace_feedback_user(self):
+        feedback_submitted_message = u'Feedback submitted. Thanks!'
+        test_comment = 'This is a test comment.'
+
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
         # launch marketplace dev and go to marketplace
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
-        marketplace.login(acct.email, acct.password)
+        home_page = marketplace.launch()
+        settings = home_page.login(acct.email, acct.password)
 
         # go to feedback tab
-        marketplace.select_setting_feedback()
+        settings.select_setting_feedback()
 
         # enter and submit your feedback
-        marketplace.enter_feedback(self.test_comment)
-        marketplace.submit_feedback()
+        settings.enter_feedback(test_comment)
+        settings.submit_feedback()
 
-        # catch the notification
-        marketplace.wait_for_notification_message_displayed()
-        message_content = marketplace.notification_message
-
-        # verify if the notification is right
-        self.assertEqual(message_content, self.feedback_submitted_message)
+        # wait for the notification
+        settings.wait_for_notification_message_displayed(feedback_submitted_message)

--- a/marketplacetests/tests/test_marketplace_forgot_pin.py
+++ b/marketplacetests/tests/test_marketplace_forgot_pin.py
@@ -14,28 +14,28 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
 
     def test_forgot_pin(self):
 
-        APP_NAME = 'Test Zippy With Me'
+        app_name = 'Test Zippy With Me'
         old_pin = '1234'
         new_pin = '1111'
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        if self.apps.is_app_installed(APP_NAME):
-            self.apps.uninstall(APP_NAME)
+        if self.apps.is_app_installed(app_name):
+            self.apps.uninstall(app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        marketplace.login(acct.email, acct.password)
+        settings = marketplace.login(acct.email, acct.password)
 
-        marketplace.set_region('United States')
+        settings.set_region('United States')
 
-        details_page = marketplace.navigate_to_app(APP_NAME)
+        details_page = settings.navigate_to_app(app_name)
         details_page.tap_install_button()
 
         payment = Payment(self.marionette)
         payment.create_pin(old_pin)
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(APP_NAME, payment.app_name)
+        self.assertIn(app_name, payment.app_name)
         payment.tap_cancel_button()
 
         marketplace.wait_for_notification_message_displayed('Payment cancelled.')
@@ -52,4 +52,4 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
         payment.confirm_pin(new_pin)
 
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(APP_NAME, payment.app_name)
+        self.assertIn(app_name, payment.app_name)

--- a/marketplacetests/tests/test_marketplace_in_app_not_you_login_feature.py
+++ b/marketplacetests/tests/test_marketplace_in_app_not_you_login_feature.py
@@ -13,24 +13,21 @@ from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 
 class TestNotYouLinkInAppPayment(MarketplaceGaiaTestCase):
 
-    APP_NAME = 'Testing In-App-Payments'
-    APP_TITLE = 'In-App-Payments'
+    def test_not_you_link_in_app_payment(self):
 
-    def setUp(self):
-        MarketplaceGaiaTestCase.setUp(self)
+        self.app_name = 'Testing In-App-Payments'
+        app_title = 'In-App-Payments'
 
         self.install_in_app_payments_test_app()
 
-    def test_not_you_link_in_app_payment(self):
-
         # Verify that the app icon is visible on one of the homescreen pages
         self.assertTrue(
-            self.homescreen.is_app_installed(self.APP_NAME),
-            'App %s not found on homescreen' % self.APP_NAME)
+            self.homescreen.is_app_installed(self.app_name),
+            'App %s not found on homescreen' % self.app_name)
 
         # Click icon and wait for h1 element displayed
-        self.homescreen.installed_app(self.APP_NAME).tap_icon()
-        Wait(self.marionette).until(lambda m: m.title == self.APP_TITLE)
+        self.homescreen.installed_app(self.app_name).tap_icon()
+        Wait(self.marionette).until(lambda m: m.title == app_title)
 
         acct = FxATestAccount(base_url=self.base_url).create_account()
 

--- a/marketplacetests/tests/test_marketplace_incorrect_pin.py
+++ b/marketplacetests/tests/test_marketplace_incorrect_pin.py
@@ -22,13 +22,13 @@ class TestMarketplaceIncorrectPin(MarketplaceGaiaTestCase):
             self.apps.uninstall(app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        marketplace.login(acct.email, acct.password)
+        settings = home_page.login(acct.email, acct.password)
 
-        marketplace.set_region('United States')
+        settings.set_region('United States')
 
-        details_page = marketplace.navigate_to_app(app_name)
+        details_page = settings.navigate_to_app(app_name)
         details_page.tap_install_button()
 
         payment = Payment(self.marionette)
@@ -37,7 +37,7 @@ class TestMarketplaceIncorrectPin(MarketplaceGaiaTestCase):
         self.assertIn(app_name, payment.app_name)
         payment.tap_cancel_button()
 
-        marketplace.wait_for_notification_message_displayed('Payment cancelled.')
+        details_page.wait_for_notification_message_displayed('Payment cancelled.')
         details_page.tap_install_button()
         payment.switch_to_payment_frame()
         payment.enter_pin(invalid_pin)

--- a/marketplacetests/tests/test_marketplace_login.py
+++ b/marketplacetests/tests/test_marketplace_login.py
@@ -9,27 +9,24 @@ from marketplacetests.marketplace.app import Marketplace
 
 class TestMarketplaceLogin(MarketplaceGaiaTestCase):
 
-    def setUp(self):
-        MarketplaceGaiaTestCase.setUp(self)
-
-        self.marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        self.marketplace.launch()
-
     def test_login_marketplace(self):
         # https://moztrap.mozilla.org/manage/case/4134/
+        marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
+        home_page = marketplace.launch()
+
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        settings = self.marketplace.tap_settings()
+        settings = home_page.tap_settings()
         ff_accounts = settings.tap_sign_in()
 
         ff_accounts.login(acct.email, acct.password)
 
         # switch back to Marketplace
-        self.marketplace.switch_to_marketplace_frame()
+        marketplace.switch_to_marketplace_frame()
 
         # wait for signed-in notification at the bottom of the screen to clear
         settings.wait_for_sign_out_button()
-        self.marketplace.wait_for_notification_message_not_displayed()
+        settings.wait_for_notification_message_not_displayed()
 
         # Verify that user is logged in
         self.assertEqual(acct.email, settings.email)

--- a/marketplacetests/tests/test_marketplace_login_during_purchase.py
+++ b/marketplacetests/tests/test_marketplace_login_during_purchase.py
@@ -14,27 +14,27 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
 
     def test_login_during_purchase(self):
 
-        APP_NAME = 'Test Zippy With Me'
-        PIN = '1234'
+        app_name = 'Test Zippy With Me'
+        pin = '1234'
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        if self.apps.is_app_installed(APP_NAME):
-            self.apps.uninstall(APP_NAME)
+        if self.apps.is_app_installed(app_name):
+            self.apps.uninstall(app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        marketplace.set_region('United States')
+        home_page.set_region('United States')
 
-        details_page = marketplace.navigate_to_app(APP_NAME)
+        details_page = home_page.navigate_to_app(app_name)
         details_page.tap_install_button()
 
         ff_accounts = FirefoxAccounts(self.marionette)
         ff_accounts.login(acct.email, acct.password)
 
         payment = Payment(self.marionette)
-        payment.create_pin(PIN)
+        payment.create_pin(pin)
 
         # Wait and check if confirm payment window appears
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(APP_NAME, payment.app_name)
+        self.assertIn(app_name, payment.app_name)

--- a/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
+++ b/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
@@ -7,7 +7,7 @@ import random
 
 from fxapom.fxapom import FxATestAccount
 
-from marketplacetests.marketplace.regions.review_box import AddReview
+from marketplacetests.marketplace.regions.add_review import AddReview
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
 
@@ -18,10 +18,11 @@ class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        app_name = marketplace.popular_apps[0].name
-        details_page = marketplace.navigate_to_app(app_name)
+        popular_apps_page = home_page.popular_apps_page
+        app_name = popular_apps_page.popular_apps[0].name
+        details_page = popular_apps_page.navigate_to_app(app_name)
 
         ff_accounts = details_page.tap_write_review(logged_in=False)
         ff_accounts.login(acct.email, acct.password)
@@ -32,10 +33,10 @@ class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
         current_time = str(time.time()).split('.')[0]
         rating = random.randint(1, 5)
         body = 'This is a test %s' % current_time
-        review_box = AddReview(self.marionette)
+        review_page = AddReview(self.marionette)
 
-        review_box.write_a_review(rating, body)
-        marketplace.wait_for_notification_message_displayed('Your review was successfully posted. Thanks!')
+        details_page = review_page.write_a_review(rating, body)
+        details_page.wait_for_notification_message_displayed('Your review was successfully posted. Thanks!')
 
         # Check if review was added correctly
         self.assertEqual(details_page.first_review_rating, rating)

--- a/marketplacetests/tests/test_marketplace_login_from_my_apps.py
+++ b/marketplacetests/tests/test_marketplace_login_from_my_apps.py
@@ -13,9 +13,9 @@ class TestMarketplaceLoginFromMyApps(MarketplaceGaiaTestCase):
         password = self.testvars['marketplace']['password']
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        settings = marketplace.tap_settings()
+        settings = home_page.tap_settings()
         my_apps = settings.go_to_my_apps_page()
 
         self.assertEqual(my_apps.login_required_message, 'You must be signed in to view your apps.')
@@ -25,11 +25,11 @@ class TestMarketplaceLoginFromMyApps(MarketplaceGaiaTestCase):
 
         # switch back to Marketplace
         marketplace.switch_to_marketplace_frame()
-        marketplace.wait_for_notification_message_displayed()
-        marketplace.wait_for_notification_message_not_displayed()
+        my_apps.wait_for_notification_message_displayed()
+        my_apps.wait_for_notification_message_not_displayed()
 
         self.wait_for_condition(lambda m: len(my_apps.my_apps_list) > 0)
-        my_apps.go_to_settings_page()
+        settings = my_apps.go_to_settings_page()
 
         # Sign out, which should return to the Marketplace home screen
         settings.tap_sign_out()

--- a/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
+++ b/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
@@ -11,33 +11,30 @@ from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 
 class TestMakeInAppPayment(MarketplaceGaiaTestCase):
 
-    APP_NAME = 'Testing In-App-Payments'
-    APP_TITLE = 'In-App-Payments'
-    PIN = '1234'
+    def test_make_an_in_app_payment(self):
 
-    def setUp(self):
-        MarketplaceGaiaTestCase.setUp(self)
+        self.app_name = 'Testing In-App-Payments'
+        app_title = 'In-App-Payments'
+        pin = '1234'
 
         self.create_account_and_change_its_region()
         self.install_in_app_payments_test_app()
 
-    def test_make_an_in_app_payment(self):
-
         # Verify that the app icon is visible on one of the homescreen pages
         self.assertTrue(
-            self.homescreen.is_app_installed(self.APP_NAME),
-            'App %s not found on homescreen' % self.APP_NAME)
+            self.homescreen.is_app_installed(self.app_name),
+            'App %s not found on homescreen' % self.app_name)
 
         # Click icon and wait for h1 element displayed
-        self.homescreen.installed_app(self.APP_NAME).tap_icon()
-        Wait(self.marionette).until(lambda m: m.title == self.APP_TITLE)
+        self.homescreen.installed_app(self.app_name).tap_icon()
+        Wait(self.marionette).until(lambda m: m.title == app_title)
 
         tester_app = InAppPayment(self.marionette)
         fxa = tester_app.tap_buy_product()
         fxa.login(self.acct.email, self.acct.password)
 
         payment = Payment(self.marionette)
-        payment.create_pin(self.PIN)
+        payment.create_pin(pin)
 
         self.assertEqual('Confirm Payment', payment.confirm_payment_header_text)
         self.assertEqual('test 0.10USD', payment.in_app_product_name)

--- a/marketplacetests/tests/test_marketplace_purchase_app.py
+++ b/marketplacetests/tests/test_marketplace_purchase_app.py
@@ -14,27 +14,27 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
 
     def test_purchase_app(self):
 
-        APP_NAME = 'Test Zippy With Me'
-        PIN = '1234'
+        app_name = 'Test Zippy With Me'
+        pin = '1234'
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        if self.apps.is_app_installed(APP_NAME):
-            self.apps.uninstall(APP_NAME)
+        if self.apps.is_app_installed(app_name):
+            self.apps.uninstall(app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        marketplace.login(acct.email, acct.password)
+        settings = home_page.login(acct.email, acct.password)
 
-        marketplace.set_region('United States')
+        settings.set_region('United States')
 
-        details_page = marketplace.navigate_to_app(APP_NAME)
+        details_page = settings.navigate_to_app(app_name)
         details_page.tap_install_button()
 
         payment = Payment(self.marionette)
-        payment.create_pin(PIN)
+        payment.create_pin(pin)
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(APP_NAME, payment.app_name)
+        self.assertIn(app_name, payment.app_name)
         payment.tap_buy_button()
         self.wait_for_downloads_to_finish()
 
@@ -42,6 +42,6 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
         confirm_install = ConfirmInstall(self.marionette)
         confirm_install.tap_confirm()
 
-        self.assertEqual('%s installed' % APP_NAME, marketplace.install_notification_message)
+        self.assertEqual('%s installed' % app_name, details_page.install_notification_message)
         marketplace.switch_to_marketplace_frame()
         self.assertEqual('Open', details_page.install_button_text)

--- a/marketplacetests/tests/test_marketplace_search_and_install_app.py
+++ b/marketplacetests/tests/test_marketplace_search_and_install_app.py
@@ -12,35 +12,31 @@ from marketplacetests.marketplace.app import Marketplace
 
 class TestSearchMarketplaceAndInstallApp(MarketplaceGaiaTestCase):
 
-    APP_INSTALLED = False
-
-    # System app confirmation button to confirm installing an app
-    _yes_button_locator = (By.ID, 'app-install-install-button')
-
-    # System app notification install message
-    _notification_install_locator = (By.CSS_SELECTOR, '#system-banner > p')
-
     def test_search_and_install_app(self):
-        marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
 
-        self.app_name = marketplace.popular_apps[0].name
+        marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
+        home_page = marketplace.launch()
+
+        popular_apps_page = home_page.popular_apps_page
+        app_name = popular_apps_page.popular_apps[0].name
+        app_author = popular_apps_page.popular_apps[0].author
 
         # Remove the app if already installed
-        if self.apps.is_app_installed(self.app_name):
+        if self.apps.is_app_installed(app_name):
             self.apps.kill(marketplace.app)
-            self.apps.uninstall(self.app_name)
-            marketplace.launch()
+            self.apps.uninstall(app_name)
+            home_page = marketplace.launch()
+            popular_apps_page = home_page.popular_apps_page
+
         marketplace.switch_to_marketplace_frame()
 
-        app_author = marketplace.popular_apps[0].author
-        results = marketplace.search(self.app_name)
+        results = popular_apps_page.search(app_name)
 
         self.assertGreater(len(results.search_results), 0, 'No results found.')
 
         first_result = results.search_results[0]
 
-        self.assertEquals(first_result.name, self.app_name, 'First app has the wrong name.')
+        self.assertEquals(first_result.name, app_name, 'First app has the wrong name.')
         self.assertEquals(first_result.author, app_author, 'First app has the wrong author.')
 
         # Find and click the install button to the install the web app
@@ -53,8 +49,7 @@ class TestSearchMarketplaceAndInstallApp(MarketplaceGaiaTestCase):
         confirm_install = ConfirmInstall(self.marionette)
         confirm_install.tap_confirm()
 
-        self.assertEqual('%s installed' % self.app_name, marketplace.install_notification_message)
-        self.APP_INSTALLED = True
+        self.assertEqual('%s installed' % app_name, results.install_notification_message)
 
         # Press Home button
         self.device.touch_home_button()
@@ -63,4 +58,4 @@ class TestSearchMarketplaceAndInstallApp(MarketplaceGaiaTestCase):
         homescreen = Homescreen(self.marionette)
         self.apps.switch_to_displayed_app()
 
-        self.assertTrue(homescreen.is_app_installed(self.app_name))
+        self.assertTrue(homescreen.is_app_installed(app_name))

--- a/marketplacetests/tests/test_marketplace_search_for_paid_app.py
+++ b/marketplacetests/tests/test_marketplace_search_for_paid_app.py
@@ -10,26 +10,26 @@ class TestSearchMarketplacePaidApp(MarketplaceGaiaTestCase):
 
     def test_search_paid_app(self):
 
-        APP_NAME = 'Test Zippy With Me'
+        app_name = 'Test Zippy With Me'
 
-        if self.apps.is_app_installed(APP_NAME):
-            self.apps.uninstall(APP_NAME)
+        if self.apps.is_app_installed(app_name):
+            self.apps.uninstall(app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
-        marketplace.launch()
+        home_page = marketplace.launch()
 
-        marketplace.set_region('United States')
+        home_page.set_region('United States')
 
-        search_results = marketplace.search(APP_NAME).search_results
+        search_results = home_page.search(app_name).search_results
 
         self.assertGreater(len(search_results), 0, 'No results found.')
 
         for result in search_results:
-            if result.name == APP_NAME:
+            if result.name == app_name:
                 saved_price = result.install_button_text
                 details_page = result.tap_app()
                 self.assertEqual(saved_price, details_page.install_button_text)
                 return True
 
         # app not found
-        self.fail('The app: %s was not found.' % APP_NAME)
+        self.fail('The app: %s was not found.' % app_name)


### PR DESCRIPTION
After experimenting and talking to a marketplace dev, it seems to make sense to introduce waits for each page, so that we can know when the page has finished loading.

I also took this opportunity to address the inconsistent casing used for variable names.

There is more refactoring to be done. There are a number of opportunities to reduce code duplication, but I would like to get this in first to see if it improves the intermittent failures that seem to plague us on CI.

Note that some tests which are currently failing will continue to fail with this PR until they are explicitly fixed. Those are:
`test_make_an_in_app_payment`
`test_marketplace_sign_in_and_sign_out_from_my_apps`
`test_not_you_link_in_app_payment`

@davehunt r?