### PR TITLE
Update tests to wait for a particular notification message to be present

### DIFF
--- a/marketplacetests/marketplace/regions/app_details.py
+++ b/marketplacetests/marketplace/regions/app_details.py
@@ -47,3 +47,9 @@ class Details(BaseRegion):
     def tap_install_button(self):
         self.wait_for_element_displayed(*self._install_button_locator)
         self.marionette.find_element(*self._install_button_locator).tap()
+
+    def wait_for_payment_cancelled_notification(self):
+        self.wait_for_notification_message('Payment cancelled.')
+
+    def wait_for_review_posted_notification(self):
+        self.wait_for_notification_message('Your review was successfully posted. Thanks!')

--- a/marketplacetests/marketplace/regions/settings.py
+++ b/marketplacetests/marketplace/regions/settings.py
@@ -77,6 +77,9 @@ class Settings(BaseRegion):
         self.wait_for_element_displayed(*self._feedback_submit_button_locator)
         self.marionette.find_element(*self._feedback_submit_button_locator).tap()
 
+    def wait_for_feedback_submitted_notification(self):
+        self.wait_for_notification_message('Feedback submitted. Thanks!')
+
 
 class MyApps(Settings):
 

--- a/marketplacetests/tests/test_marketplace_add_review.py
+++ b/marketplacetests/tests/test_marketplace_add_review.py
@@ -32,9 +32,8 @@ class TestMarketplaceAddReview(MarketplaceGaiaTestCase):
         review_page = details_page.tap_write_review()
         details_page = review_page.write_a_review(rating, body)
 
-        details_page.wait_for_notification_message_displayed()
+        details_page.wait_for_review_posted_notification()
 
         # Check if review was added correctly
-        self.assertEqual(details_page.notification_message, "Your review was successfully posted. Thanks!")
         self.assertEqual(details_page.first_review_rating, rating)
         self.assertEqual(details_page.first_review_body, body)

--- a/marketplacetests/tests/test_marketplace_feedback_anonymous.py
+++ b/marketplacetests/tests/test_marketplace_feedback_anonymous.py
@@ -9,7 +9,6 @@ from marketplacetests.marketplace.app import Marketplace
 class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
 
     def test_marketplace_feedback_anonymous(self):
-        feedback_submitted_message = u'Feedback submitted. Thanks!'
         test_comment = 'This is a test comment.'
 
         # launch marketplace dev and go to marketplace
@@ -25,4 +24,4 @@ class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
         settings.submit_feedback()
 
         # wait for the notification
-        settings.wait_for_notification_message_displayed(feedback_submitted_message)
+        settings.wait_for_feedback_submitted_notification()

--- a/marketplacetests/tests/test_marketplace_feedback_login.py
+++ b/marketplacetests/tests/test_marketplace_feedback_login.py
@@ -10,7 +10,6 @@ from marketplacetests.marketplace.app import Marketplace
 class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
 
     def test_marketplace_feedback_user(self):
-        feedback_submitted_message = u'Feedback submitted. Thanks!'
         test_comment = 'This is a test comment.'
 
         acct = FxATestAccount(base_url=self.base_url).create_account()
@@ -28,4 +27,4 @@ class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
         settings.submit_feedback()
 
         # wait for the notification
-        settings.wait_for_notification_message_displayed(feedback_submitted_message)
+        settings.wait_for_feedback_submitted_notification()

--- a/marketplacetests/tests/test_marketplace_forgot_pin.py
+++ b/marketplacetests/tests/test_marketplace_forgot_pin.py
@@ -25,7 +25,7 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        settings = marketplace.login(acct.email, acct.password)
+        settings = home_page.login(acct.email, acct.password)
 
         settings.set_region('United States')
 
@@ -38,7 +38,7 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
         self.assertIn(app_name, payment.app_name)
         payment.tap_cancel_button()
 
-        marketplace.wait_for_notification_message_displayed('Payment cancelled.')
+        details_page.wait_for_payment_cancelled_notification()
         details_page.tap_install_button()
         payment.switch_to_payment_frame()
         payment.tap_forgot_pin()

--- a/marketplacetests/tests/test_marketplace_incorrect_pin.py
+++ b/marketplacetests/tests/test_marketplace_incorrect_pin.py
@@ -37,7 +37,7 @@ class TestMarketplaceIncorrectPin(MarketplaceGaiaTestCase):
         self.assertIn(app_name, payment.app_name)
         payment.tap_cancel_button()
 
-        details_page.wait_for_notification_message_displayed('Payment cancelled.')
+        details_page.wait_for_payment_cancelled_notification()
         details_page.tap_install_button()
         payment.switch_to_payment_frame()
         payment.enter_pin(invalid_pin)

--- a/marketplacetests/tests/test_marketplace_login.py
+++ b/marketplacetests/tests/test_marketplace_login.py
@@ -24,9 +24,9 @@ class TestMarketplaceLogin(MarketplaceGaiaTestCase):
         # switch back to Marketplace
         marketplace.switch_to_marketplace_frame()
 
-        # wait for signed-in notification at the bottom of the screen to clear
+        # wait for the expected notification, and for user to be signed in
+        settings.wait_for_login_success_notification()
         settings.wait_for_sign_out_button()
-        settings.wait_for_notification_message_not_displayed()
 
         # Verify that user is logged in
         self.assertEqual(acct.email, settings.email)

--- a/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
+++ b/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
@@ -36,7 +36,7 @@ class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
         review_page = AddReview(self.marionette)
 
         details_page = review_page.write_a_review(rating, body)
-        details_page.wait_for_notification_message_displayed('Your review was successfully posted. Thanks!')
+        details_page.wait_for_review_posted_notification()
 
         # Check if review was added correctly
         self.assertEqual(details_page.first_review_rating, rating)

--- a/marketplacetests/tests/test_marketplace_login_from_my_apps.py
+++ b/marketplacetests/tests/test_marketplace_login_from_my_apps.py
@@ -25,8 +25,7 @@ class TestMarketplaceLoginFromMyApps(MarketplaceGaiaTestCase):
 
         # switch back to Marketplace
         marketplace.switch_to_marketplace_frame()
-        my_apps.wait_for_notification_message_displayed()
-        my_apps.wait_for_notification_message_not_displayed()
+        my_apps.wait_for_login_success_notification()
 
         self.wait_for_condition(lambda m: len(my_apps.my_apps_list) > 0)
         settings = my_apps.go_to_settings_page()


### PR DESCRIPTION
Fixes issue #97. We will now be always waiting for a specific notification message to be present, rather than just for any notification to be displayed. More details in issue #97.

@davehunt r?