### PR TITLE
Xfail the in-app payments tests

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -18,6 +18,8 @@ offline = false
 [test_marketplace_incorrect_pin.py]
 
 [test_marketplace_in_app_not_you_logout_feature.py]
+# Bug 1162010 - Sign in button takes users to create account flow if they haven't previously logged in
+expected = fail
 
 [test_marketplace_login.py]
 
@@ -26,11 +28,14 @@ offline = false
 [test_marketplace_login_from_app_details_page.py]
 
 [test_marketplace_make_an_in_app_payment.py]
+# Bug 1162010 - Sign in button takes users to create account flow if they haven't previously logged in
+expected = fail
 
 [test_marketplace_purchase_app.py]
 
 [test_marketplace_search_and_install_app.py]
-disabled = Bug 1157317 - Mismatch between app name and manifest name
+# Bug 1157317 - Mismatch between app name and manifest name
+expected = fail
 
 [test_marketplace_search_for_paid_app.py]
 


### PR DESCRIPTION
Change test_marketplace_search_and_install_app from disabled to xfailed

All three of these tests should be xfailed as there are bugs open for fixes for them.

@davehunt r?