### PR TITLE
Use two-letter region code for set_region()

### DIFF
--- a/marketplacetests/tests/test_marketplace_create_confirm_pin.py
+++ b/marketplacetests/tests/test_marketplace_create_confirm_pin.py
@@ -25,7 +25,7 @@ class TestMarketplaceCreateConfirmPin(MarketplaceGaiaTestCase):
 
         home_page.login(acct.email, acct.password)
 
-        home_page.set_region('United States')
+        home_page.set_region('us')
 
         details_page = home_page.navigate_to_app(app_name)
         details_page.tap_install_button()

--- a/marketplacetests/tests/test_marketplace_forgot_pin.py
+++ b/marketplacetests/tests/test_marketplace_forgot_pin.py
@@ -27,7 +27,7 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
 
         home_page.login(acct.email, acct.password)
 
-        home_page.set_region('United States')
+        home_page.set_region('us')
 
         details_page = home_page.navigate_to_app(app_name)
         details_page.tap_install_button()

--- a/marketplacetests/tests/test_marketplace_incorrect_pin.py
+++ b/marketplacetests/tests/test_marketplace_incorrect_pin.py
@@ -26,7 +26,7 @@ class TestMarketplaceIncorrectPin(MarketplaceGaiaTestCase):
 
         home_page.login(acct.email, acct.password)
 
-        home_page.set_region('United States')
+        home_page.set_region('us')
 
         details_page = home_page.navigate_to_app(app_name)
         details_page.tap_install_button()

--- a/marketplacetests/tests/test_marketplace_login_during_purchase.py
+++ b/marketplacetests/tests/test_marketplace_login_during_purchase.py
@@ -24,7 +24,7 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.set_region('United States')
+        home_page.set_region('us')
 
         details_page = home_page.navigate_to_app(app_name)
         details_page.tap_install_button()

--- a/marketplacetests/tests/test_marketplace_purchase_app.py
+++ b/marketplacetests/tests/test_marketplace_purchase_app.py
@@ -27,7 +27,7 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
 
         home_page.login(acct.email, acct.password)
 
-        home_page.set_region('United States')
+        home_page.set_region('us')
 
         details_page = home_page.navigate_to_app(self.app_name)
         details_page.tap_install_button()

--- a/marketplacetests/tests/test_marketplace_search_for_paid_app.py
+++ b/marketplacetests/tests/test_marketplace_search_for_paid_app.py
@@ -17,7 +17,7 @@ class TestSearchMarketplacePaidApp(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.set_region('United States')
+        home_page.set_region('us')
 
         search_results = home_page.search(app_name).search_results
 


### PR DESCRIPTION
This fixes all the failures as currently seen at https://webqa-ci.mozilla.com/job/marketplace.mozilla-b2g32_v2_0.nightly/206/testReport/

The code for the region select has changed to use two character country codes instead of the full country name.

@davehunt r?