### PR TITLE
Restore coverage for Marketplace tests on FxOS

### DIFF
--- a/marketplacetests/marketplace/pages/app_details.py
+++ b/marketplacetests/marketplace/pages/app_details.py
@@ -48,8 +48,5 @@ class Details(BasePage):
         self.wait_for_element_displayed(*self._install_button_locator)
         self.marionette.find_element(*self._install_button_locator).tap()
 
-    def wait_for_payment_cancelled_notification(self):
-        self.wait_for_notification_message('Payment cancelled.')
-
     def wait_for_review_posted_notification(self):
         self.wait_for_notification_message('Your review was successfully posted. Thanks!')

--- a/marketplacetests/marketplace/pages/debug.py
+++ b/marketplacetests/marketplace/pages/debug.py
@@ -12,6 +12,7 @@ class Debug(BasePage):
     _page_loaded_locator = (By.CSS_SELECTOR, 'section.debug')
 
     _region_select_locator = (By.ID, 'debug-region')
+    _back_button_locator = (By.CSS_SELECTOR, 'mkt-nav-toggle button')
 
     def select_region(self, region):
         element = self.marionette.find_element(*self._region_select_locator)
@@ -22,3 +23,11 @@ class Debug(BasePage):
         element.tap()
         self.select(region)
         self.switch_to_marketplace_frame()
+
+    def tap_back(self):
+        back_button = self.marionette.find_element(*self._nav_menu_toggle_locator)
+        # This workaround is required for gaia v2.0, but can be removed in later versions
+        # as the bug has been fixed
+        # Bug 937053 - tap() method should calculate elementInView from the coordinates of the tap
+        self.marionette.execute_script('arguments[0].scrollIntoView(false);', [back_button])
+        back_button.tap()

--- a/marketplacetests/marketplace_gaia_test.py
+++ b/marketplacetests/marketplace_gaia_test.py
@@ -4,12 +4,13 @@
 
 import os
 
+from gaiatest.apps.homescreen.regions.confirm_install import ConfirmInstall
+from gaiatest.apps.homescreen.app import Homescreen
 from gaiatest.gaia_test import GaiaTestCase
 from marionette.by import By
 
-from gaiatest.apps.homescreen.regions.confirm_install import ConfirmInstall
-from gaiatest.apps.homescreen.app import Homescreen
 from marketplacetests.marketplace.app import Marketplace
+from marketplacetests.marketplace.pages.base import BasePage
 
 
 class MarketplaceGaiaTestCase(GaiaTestCase):
@@ -76,3 +77,18 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
     def wait_for_downloads_to_finish(self):
         self.marionette.switch_to_frame()
         self.wait_for_element_not_displayed(*self._statusbar_downloads_icon_locator)
+
+    def tap_install_button_of_first_paid_app(self):
+        """This method taps on the install button of the first paid app and stores the name of that app in self.app_name for future use by the test.
+
+        It also verifies that the targeted app is not already installed
+        and returns the SearchResults page object to the caller.
+        """
+        page = BasePage(self.marionette)
+        search_results_page = page.search_for_paid_apps()
+        # The first paid app's app object is search_results_page.search_results[0]
+        self.app_name = search_results_page.search_results[0].name
+        self.assertFalse(page.is_app_installed(self.app_name))
+        # We need to re-find the app object as the call to is_app_installed loses context
+        search_results_page.search_results[0].tap_install_button()
+        return search_results_page

--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -32,8 +32,12 @@ expected = fail
 expected = fail
 
 [test_marketplace_purchase_app.py]
+# Bug 1157317 - Mismatch between app name and manifest name
+expected = fail
 
 [test_marketplace_search_and_install_app.py]
+# Issue 115 - test_search_and_install_app will fail until flag flips which changes button text
+expected = fail
 
 [test_marketplace_search_for_paid_app.py]
 

--- a/marketplacetests/tests/test_marketplace_add_review.py
+++ b/marketplacetests/tests/test_marketplace_add_review.py
@@ -19,7 +19,7 @@ class TestMarketplaceAddReview(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        app_name = home_page.first_free_app_name
+        app_name = home_page.first_free_app['name']
 
         home_page.login(acct.email, acct.password)
         details_page = home_page.navigate_to_app(app_name)

--- a/marketplacetests/tests/test_marketplace_create_confirm_pin.py
+++ b/marketplacetests/tests/test_marketplace_create_confirm_pin.py
@@ -13,24 +13,16 @@ class TestMarketplaceCreateConfirmPin(MarketplaceGaiaTestCase):
 
     def test_create_confirm_pin(self):
 
-        app_name = 'Test Zippy With Me'
         pin = '1234'
         acct = FxATestAccount(base_url=self.base_url).create_account()
-
-        if self.apps.is_app_installed(app_name):
-            raise Exception('The app %s is already installed.' % app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
         home_page.login(acct.email, acct.password)
-
-        home_page.set_region('us')
-
-        details_page = home_page.navigate_to_app(app_name)
-        details_page.tap_install_button()
+        self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)
         payment.create_pin(pin)
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(app_name, payment.app_name)
+        self.assertIn(self.app_name, payment.app_name)

--- a/marketplacetests/tests/test_marketplace_forgot_pin.py
+++ b/marketplacetests/tests/test_marketplace_forgot_pin.py
@@ -14,32 +14,25 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
 
     def test_forgot_pin(self):
 
-        app_name = 'Test Zippy With Me'
         old_pin = '1234'
         new_pin = '1111'
         acct = FxATestAccount(base_url=self.base_url).create_account()
-
-        if self.apps.is_app_installed(app_name):
-            raise Exception('The app %s is already installed.' % app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
         home_page.login(acct.email, acct.password)
-
-        home_page.set_region('us')
-
-        details_page = home_page.navigate_to_app(app_name)
-        details_page.tap_install_button()
+        search_results_page = self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)
         payment.create_pin(old_pin)
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(app_name, payment.app_name)
+        self.assertIn(self.app_name, payment.app_name)
         payment.tap_cancel_button()
 
-        details_page.wait_for_payment_cancelled_notification()
-        details_page.tap_install_button()
+        search_results_page.wait_for_payment_cancelled_notification()
+        search_results_page.search_results[0].tap_install_button()
+
         payment.switch_to_payment_frame()
         payment.tap_forgot_pin()
         payment.tap_reset_button()
@@ -52,4 +45,4 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
         payment.confirm_pin(new_pin)
 
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(app_name, payment.app_name)
+        self.assertIn(self.app_name, payment.app_name)

--- a/marketplacetests/tests/test_marketplace_incorrect_pin.py
+++ b/marketplacetests/tests/test_marketplace_incorrect_pin.py
@@ -13,32 +13,25 @@ class TestMarketplaceIncorrectPin(MarketplaceGaiaTestCase):
 
     def test_incorrect_pin(self):
 
-        app_name = 'Test Zippy With Me'
         valid_pin = '1234'
         invalid_pin = '1111'
         acct = FxATestAccount(base_url=self.base_url).create_account()
-
-        if self.apps.is_app_installed(app_name):
-            raise Exception('The app %s is already installed.' % app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
         home_page.login(acct.email, acct.password)
-
-        home_page.set_region('us')
-
-        details_page = home_page.navigate_to_app(app_name)
-        details_page.tap_install_button()
+        search_results_page = self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)
         payment.create_pin(valid_pin)
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(app_name, payment.app_name)
+        self.assertIn(self.app_name, payment.app_name)
         payment.tap_cancel_button()
 
-        details_page.wait_for_payment_cancelled_notification()
-        details_page.tap_install_button()
+        search_results_page.wait_for_payment_cancelled_notification()
+        search_results_page.search_results[0].tap_install_button()
+
         payment.switch_to_payment_frame()
         payment.enter_pin(invalid_pin)
         self.assertEqual('Wrong PIN', payment.pin_error)

--- a/marketplacetests/tests/test_marketplace_login_during_purchase.py
+++ b/marketplacetests/tests/test_marketplace_login_during_purchase.py
@@ -14,20 +14,13 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
 
     def test_login_during_purchase(self):
 
-        app_name = 'Test Zippy With Me'
         pin = '1234'
         acct = FxATestAccount(base_url=self.base_url).create_account()
-
-        if self.apps.is_app_installed(app_name):
-            raise Exception('The app %s is already installed.' % app_name)
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.set_region('us')
-
-        details_page = home_page.navigate_to_app(app_name)
-        details_page.tap_install_button()
+        self.tap_install_button_of_first_paid_app()
 
         ff_accounts = FirefoxAccounts(self.marionette)
         ff_accounts.login(acct.email, acct.password)
@@ -37,4 +30,4 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
 
         # Wait and check if confirm payment window appears
         payment.wait_for_buy_app_section_displayed()
-        self.assertIn(app_name, payment.app_name)
+        self.assertIn(self.app_name, payment.app_name)

--- a/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
+++ b/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
@@ -20,7 +20,8 @@ class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        app_name = home_page.first_free_app_name
+        app_name = home_page.first_free_app['name']
+
         details_page = home_page.navigate_to_app(app_name)
 
         ff_accounts = details_page.tap_write_review(logged_in=False)

--- a/marketplacetests/tests/test_marketplace_purchase_app.py
+++ b/marketplacetests/tests/test_marketplace_purchase_app.py
@@ -12,25 +12,16 @@ from marketplacetests.payment.app import Payment
 
 class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
 
-    app_name = 'Test Zippy With Me'
-
     def test_purchase_app(self):
 
         pin = '1234'
         acct = FxATestAccount(base_url=self.base_url).create_account()
 
-        if self.apps.is_app_installed(self.app_name):
-            raise Exception('The app %s is already installed.' % self.app_name)
-
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
         home_page.login(acct.email, acct.password)
-
-        home_page.set_region('us')
-
-        details_page = home_page.navigate_to_app(self.app_name)
-        details_page.tap_install_button()
+        search_results_page = self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)
         payment.create_pin(pin)
@@ -43,9 +34,12 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
         confirm_install = ConfirmInstall(self.marionette)
         confirm_install.tap_confirm()
 
-        self.assertEqual('%s installed' % self.app_name, details_page.install_notification_message)
+        self.assertEqual('%s installed' % self.app_name, search_results_page.install_notification_message)
         marketplace.switch_to_marketplace_frame()
-        self.assertEqual('Open app', details_page.install_button_text)
+
+        app = search_results_page.search_results[0]
+
+        self.assertEqual('Open app', app.install_button_text)
 
     def tearDown(self):
         self.apps.uninstall(self.app_name)

--- a/marketplacetests/tests/test_marketplace_search_and_install_app.py
+++ b/marketplacetests/tests/test_marketplace_search_and_install_app.py
@@ -17,10 +17,8 @@ class TestSearchMarketplaceAndInstallApp(MarketplaceGaiaTestCase):
         home_page = marketplace.launch()
 
         # Find a free app to install
-        results = home_page.search(':free').search_results
-        app = results[0]
-        self.app_name = app.name
-        app_author = app.author
+        app = home_page.first_free_app
+        self.app_name = app['name']
 
         if self.apps.is_app_installed(self.app_name):
             raise Exception('The app %s is already installed.' % self.app_name)
@@ -35,7 +33,9 @@ class TestSearchMarketplaceAndInstallApp(MarketplaceGaiaTestCase):
         first_result = results[0]
 
         self.assertEquals(first_result.name, self.app_name, 'First app has the wrong name.')
-        self.assertEquals(first_result.author, app_author, 'First app has the wrong author.')
+        self.assertEquals(first_result.author, app['author'],
+                          'First app has the wrong author. Found %s but expected %s.' %
+                          (first_result.author, app['author']))
 
         # Find and click the install button to the install the web app
         self.assertEquals(first_result.install_button_text, 'Install for free', 'Incorrect button label.')

--- a/marketplacetests/tests/test_marketplace_search_for_paid_app.py
+++ b/marketplacetests/tests/test_marketplace_search_for_paid_app.py
@@ -10,25 +10,13 @@ class TestSearchMarketplacePaidApp(MarketplaceGaiaTestCase):
 
     def test_search_paid_app(self):
 
-        app_name = 'Test Zippy With Me'
-        if self.apps.is_app_installed(app_name):
-            raise Exception('The app %s is already installed.' % app_name)
-
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
         home_page.set_region('us')
 
-        search_results = home_page.search(app_name).search_results
+        app = home_page.search(':paid').search_results[0]
 
-        self.assertGreater(len(search_results), 0, 'No results found.')
-
-        for result in search_results:
-            if result.name == app_name:
-                saved_price = result.install_button_text
-                details_page = result.tap_app()
-                self.assertEqual(saved_price, details_page.install_button_text)
-                return True
-
-        # app not found
-        self.fail('The app: %s was not found.' % app_name)
+        saved_price = app.install_button_text
+        details_page = app.tap_app()
+        self.assertEqual(saved_price, details_page.install_button_text)


### PR DESCRIPTION
This PR includes a number of changes which should fix most of the tests, and xfails a couple of others.

This addresses issue #114 and includes the xfail mentioned in issue #115, it also includes some refactoring as mentioned in issue #96 

Among the changes:
Use first paid app rather than a specific app
Fix back button locator