### PR TITLE
Use full name of country for set_region()

### DIFF
--- a/marketplacetests/marketplace/pages/base.py
+++ b/marketplacetests/marketplace/pages/base.py
@@ -132,7 +132,7 @@ class BasePage(Marketplace):
         return NavMenu(self.marionette)
 
     def search_for_paid_apps(self):
-        self.set_region('us')
+        self.set_region('United States')
         return self.search(':paid')
 
     def is_app_installed(self, name):

--- a/marketplacetests/tests/test_marketplace_search_for_paid_app.py
+++ b/marketplacetests/tests/test_marketplace_search_for_paid_app.py
@@ -13,7 +13,7 @@ class TestSearchMarketplacePaidApp(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.set_region('us')
+        home_page.set_region('United States')
 
         app = home_page.search(':paid').search_results[0]
 


### PR DESCRIPTION
This should restore coverage for they payments tests on FxOS. 

@krupa r? for this simple change