### PR TITLE
Fixes issue #115 - test_search_and_install_app will fail until flag flips which changes button text

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -36,8 +36,6 @@ expected = fail
 expected = fail
 
 [test_marketplace_search_and_install_app.py]
-# Issue 115 - test_search_and_install_app will fail until flag flips which changes button text
-expected = fail
 
 [test_marketplace_search_for_paid_app.py]
 


### PR DESCRIPTION
Unxfail test_marketplace_search_and_install_app because the flag has flipped

@davehunt r?