### PR TITLE
Update marketplace-tests-gaia to use FxAPom 1.4

### DIFF
--- a/marketplacetests/marketplace_gaia_test.py
+++ b/marketplacetests/marketplace_gaia_test.py
@@ -3,7 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+from urlparse import urlparse
 
+from fxapom.fxapom import DEV_URL, FxATestAccount, PROD_URL
 from gaiatest.apps.homescreen.regions.confirm_install import ConfirmInstall
 from gaiatest.apps.homescreen.app import Homescreen
 from gaiatest.gaia_test import GaiaTestCase
@@ -29,6 +31,11 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
         # This is used to tell FxA whether to create a dev or prod account
         self.base_url = 'https://marketplace-dev.allizom.org'
 
+    def create_firefox_account(self):
+        prod_hosts = ['marketplace.firefox.com', 'marketplace.allizom.org']
+        api_url = PROD_URL if urlparse(self.base_url).hostname in prod_hosts else DEV_URL
+        return FxATestAccount(api_url)
+
     def install_in_app_payments_test_app(self, app_name):
 
         homescreen = Homescreen(self.marionette)
@@ -51,14 +58,6 @@ class MarketplaceGaiaTestCase(GaiaTestCase):
         self.apps.switch_to_displayed_app()
         homescreen.wait_for_app_icon_present(app_name)
         return homescreen
-
-    @property
-    def email(self):
-        return self.acct.email
-
-    @property
-    def password(self):
-        return self.acct.password
 
     def install_certs(self):
         """ Install the marketplace-dev certs and set the pref required """

--- a/marketplacetests/tests/test_marketplace_add_review.py
+++ b/marketplacetests/tests/test_marketplace_add_review.py
@@ -5,8 +5,6 @@
 import time
 import random
 
-from fxapom.fxapom import FxATestAccount
-
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
 
@@ -14,14 +12,14 @@ from marketplacetests.marketplace.app import Marketplace
 class TestMarketplaceAddReview(MarketplaceGaiaTestCase):
 
     def test_add_review(self):
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
         app_name = home_page.first_free_app['name']
 
-        home_page.login(acct.email, acct.password)
+        home_page.login(account.email, account.password)
         details_page = home_page.navigate_to_app(app_name)
 
         current_time = str(time.time()).split('.')[0]

--- a/marketplacetests/tests/test_marketplace_create_confirm_pin.py
+++ b/marketplacetests/tests/test_marketplace_create_confirm_pin.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from fxapom.fxapom import FxATestAccount
-
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
 from marketplacetests.payment.app import Payment
@@ -14,12 +12,12 @@ class TestMarketplaceCreateConfirmPin(MarketplaceGaiaTestCase):
     def test_create_confirm_pin(self):
 
         pin = '1234'
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.login(acct.email, acct.password)
+        home_page.login(account.email, account.password)
         self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)

--- a/marketplacetests/tests/test_marketplace_feedback_login.py
+++ b/marketplacetests/tests/test_marketplace_feedback_login.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from fxapom.fxapom import FxATestAccount
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
@@ -12,11 +11,11 @@ class TestMarketplaceFeedback(MarketplaceGaiaTestCase):
     def test_marketplace_feedback_user(self):
         test_comment = 'This is a test comment.'
 
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
-        home_page.login(acct.email, acct.password)
+        home_page.login(account.email, account.password)
 
         feedback = home_page.show_menu().tap_feedback()
         feedback.enter_feedback(test_comment)

--- a/marketplacetests/tests/test_marketplace_forgot_pin.py
+++ b/marketplacetests/tests/test_marketplace_forgot_pin.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from fxapom.fxapom import FxATestAccount
-
 from marketplacetests.firefox_accounts.app import FirefoxAccounts
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
@@ -16,12 +14,12 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
 
         old_pin = '1234'
         new_pin = '1111'
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.login(acct.email, acct.password)
+        home_page.login(account.email, account.password)
         search_results_page = self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)
@@ -38,7 +36,7 @@ class TestMarketplaceForgotPin(MarketplaceGaiaTestCase):
         payment.tap_reset_button()
 
         ff_accounts = FirefoxAccounts(self.marionette)
-        ff_accounts.login(acct.email, acct.password)
+        ff_accounts.login(account.email, account.password)
 
         payment.switch_to_payment_frame()
         payment.enter_pin(new_pin)

--- a/marketplacetests/tests/test_marketplace_in_app_not_you_logout_feature.py
+++ b/marketplacetests/tests/test_marketplace_in_app_not_you_logout_feature.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette import Wait
-from fxapom.fxapom import FxATestAccount
 
 from marketplacetests.payment.app import InAppPayment
 from marketplacetests.in_app_payments.in_app import InAppPaymentTester
@@ -19,7 +18,7 @@ class TestNotYouLogoutFromInAppPayment(MarketplaceGaiaTestCase):
 
     def test_not_you_logout_from_in_app_payment(self):
 
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
         homescreen = self.install_in_app_payments_test_app(self.test_data['app_name'])
 
         # Verify that the app icon is visible on one of the homescreen pages
@@ -32,14 +31,14 @@ class TestNotYouLogoutFromInAppPayment(MarketplaceGaiaTestCase):
         Wait(self.marionette).until(lambda m: m.title == self.test_data['app_title'])
 
         fxa = self.tester_app.tap_buy_product(self.test_data['product'])
-        fxa.login(acct.email, acct.password)
+        fxa.login(account.email, account.password)
 
         payment = InAppPayment(self.marionette)
         payment.tap_cancel_pin()
 
         fxa = self.tester_app.tap_buy_product(self.test_data['product'])
         self.assertTrue(fxa.is_not_you_logout_link_visible)
-        self.assertEqual('You are signed in as: %s' % acct.email, 'You are signed in as: %s' % fxa.email_text)
+        self.assertEqual('You are signed in as: %s' % account.email, 'You are signed in as: %s' % fxa.email_text)
 
         fxa.tap_not_you()
         fxa.wait_for_password_field_visible()

--- a/marketplacetests/tests/test_marketplace_incorrect_pin.py
+++ b/marketplacetests/tests/test_marketplace_incorrect_pin.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from fxapom.fxapom import FxATestAccount
-
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
 from marketplacetests.payment.app import Payment
@@ -15,12 +13,12 @@ class TestMarketplaceIncorrectPin(MarketplaceGaiaTestCase):
 
         valid_pin = '1234'
         invalid_pin = '1111'
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.login(acct.email, acct.password)
+        home_page.login(account.email, account.password)
         search_results_page = self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)

--- a/marketplacetests/tests/test_marketplace_login.py
+++ b/marketplacetests/tests/test_marketplace_login.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from fxapom.fxapom import FxATestAccount
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
@@ -14,9 +13,9 @@ class TestMarketplaceLogin(MarketplaceGaiaTestCase):
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
-        home_page.login(acct.email, acct.password)
+        home_page.login(account.email, account.password)
 
         # switch back to Marketplace
         marketplace.switch_to_marketplace_frame()
@@ -27,7 +26,7 @@ class TestMarketplaceLogin(MarketplaceGaiaTestCase):
         settings.wait_for_sign_out_button()
 
         # Verify that user is logged in
-        self.assertEqual(acct.email, settings.email)
+        self.assertEqual(account.email, settings.email)
 
         # Sign out, which should return to the Marketplace home screen
         settings.tap_sign_out()

--- a/marketplacetests/tests/test_marketplace_login_during_purchase.py
+++ b/marketplacetests/tests/test_marketplace_login_during_purchase.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from fxapom.fxapom import FxATestAccount
-
 from marketplacetests.payment.app import Payment
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
@@ -15,7 +13,7 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
     def test_login_during_purchase(self):
 
         pin = '1234'
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         marketplace.launch()
@@ -23,7 +21,7 @@ class TestMarketplaceLoginDuringPurchase(MarketplaceGaiaTestCase):
         self.tap_install_button_of_first_paid_app()
 
         ff_accounts = FirefoxAccounts(self.marionette)
-        ff_accounts.login(acct.email, acct.password)
+        ff_accounts.login(account.email, account.password)
 
         payment = Payment(self.marionette)
         payment.create_pin(pin)

--- a/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
+++ b/marketplacetests/tests/test_marketplace_login_from_app_details_page.py
@@ -5,8 +5,6 @@
 import time
 import random
 
-from fxapom.fxapom import FxATestAccount
-
 from marketplacetests.marketplace.pages.add_review import AddReview
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
 from marketplacetests.marketplace.app import Marketplace
@@ -15,7 +13,7 @@ from marketplacetests.marketplace.app import Marketplace
 class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
 
     def test_marketplace_login_from_app_details_page(self):
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
@@ -25,7 +23,7 @@ class TestMarketplaceLoginFromAppDetailsPage(MarketplaceGaiaTestCase):
         details_page = home_page.navigate_to_app(app_name)
 
         ff_accounts = details_page.tap_write_review(logged_in=False)
-        ff_accounts.login(acct.email, acct.password)
+        ff_accounts.login(account.email, account.password)
 
         # switch back to Marketplace
         marketplace.switch_to_marketplace_frame()

--- a/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
+++ b/marketplacetests/tests/test_marketplace_make_an_in_app_payment.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from fxapom.fxapom import FxATestAccount
 from marionette import Wait
 
 from marketplacetests.in_app_payments.in_app import InAppPaymentTester
@@ -20,7 +19,7 @@ class TestMakeInAppPayment(MarketplaceGaiaTestCase):
 
     def test_make_an_in_app_payment(self):
 
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
         homescreen = self.install_in_app_payments_test_app(self.test_data['app_name'])
 
         # Verify that the app icon is visible on one of the homescreen pages
@@ -33,7 +32,7 @@ class TestMakeInAppPayment(MarketplaceGaiaTestCase):
         Wait(self.marionette).until(lambda m: m.title == self.test_data['app_title'])
 
         fxa = self.tester_app.tap_buy_product(self.test_data['product'])
-        fxa.login(acct.email, acct.password)
+        fxa.login(account.email, account.password)
 
         payment = InAppPayment(self.marionette)
         payment.create_pin(self.test_data['pin'])

--- a/marketplacetests/tests/test_marketplace_purchase_app.py
+++ b/marketplacetests/tests/test_marketplace_purchase_app.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from fxapom.fxapom import FxATestAccount
 from gaiatest.apps.homescreen.regions.confirm_install import ConfirmInstall
 
 from marketplacetests.marketplace_gaia_test import MarketplaceGaiaTestCase
@@ -15,12 +14,12 @@ class TestMarketplacePurchaseApp(MarketplaceGaiaTestCase):
     def test_purchase_app(self):
 
         pin = '1234'
-        acct = FxATestAccount(base_url=self.base_url).create_account()
+        account = self.create_firefox_account()
 
         marketplace = Marketplace(self.marionette, self.MARKETPLACE_DEV_NAME)
         home_page = marketplace.launch()
 
-        home_page.login(acct.email, acct.password)
+        home_page.login(account.email, account.password)
         search_results_page = self.tap_install_button_of_first_paid_app()
 
         payment = Payment(self.marionette)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (OSError, IOError):
     description = ''
 
 dependencies = ['gaiatest-v2.0',
-                'fxapom==1.2']
+                'fxapom==1.4']
 
 setup(name='marketplacetests',
       version='1.0',


### PR DESCRIPTION
@davehunt This update is pretty much the same simple change as was needed in https://github.com/mozilla/marketplace-tests/pull/701, but there are more changes because:

1. We don't have pytest fixtures, so we are creating the account in each test.
2. This code was still using fxapom 1.2, so it was still using the `base_url` so that needed to be changed as well.

As with the other PR, this needs to wait for fxapom 1.4 to be released, and I'll wait on that until you've had a chance to look over this PR as well.