### PR TITLE
Mark test_marketplace_purchase_app as expected to pass

### DIFF
--- a/marketplacetests/tests/manifest.ini
+++ b/marketplacetests/tests/manifest.ini
@@ -32,8 +32,6 @@ expected = fail
 expected = fail
 
 [test_marketplace_purchase_app.py]
-# Bug 1157317 - Mismatch between app name and manifest name
-expected = fail
 
 [test_marketplace_search_and_install_app.py]
 


### PR DESCRIPTION
This test has been passing since at least 11-Jul-2015. Let's mark it as expected to pass, and revisit if the original issue returns. Pinging @krupa for review.

See [bug 1157317](https://bugzilla.mozilla.org/show_bug.cgi?id=1157317) and [bug 1196162](https://bugzilla.mozilla.org/show_bug.cgi?id=1196162) for more details.